### PR TITLE
refactor: `NonEmpty` for `RaceControl`

### DIFF
--- a/app/app/Route/Debug.elm
+++ b/app/app/Route/Debug.elm
@@ -8,7 +8,7 @@ import FatalError exposing (FatalError)
 import Html.Styled exposing (div, header, input, nav, text)
 import Html.Styled.Attributes as Attributes exposing (css, type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
-import List.NonEmpty
+import List.NonEmpty as NonEmpty
 import Motorsport.Analysis exposing (Analysis)
 import Motorsport.Clock as Clock
 import Motorsport.Duration as Duration
@@ -246,9 +246,7 @@ raceControlToLeaderboard { lapCount, cars } =
     let
         items =
             cars
-                |> List.NonEmpty.toList
-                |> List.filter (\car -> car.metaData.carNumber == "2")
-                |> List.head
+                |> NonEmpty.find (\car -> car.metaData.carNumber == "2")
                 |> Maybe.map
                     (\car ->
                         car.laps

--- a/app/app/Route/Debug.elm
+++ b/app/app/Route/Debug.elm
@@ -8,6 +8,7 @@ import FatalError exposing (FatalError)
 import Html.Styled exposing (div, header, input, nav, text)
 import Html.Styled.Attributes as Attributes exposing (css, type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
+import List.NonEmpty
 import Motorsport.Analysis exposing (Analysis)
 import Motorsport.Clock as Clock
 import Motorsport.Duration as Duration
@@ -245,6 +246,7 @@ raceControlToLeaderboard { lapCount, cars } =
     let
         items =
             cars
+                |> List.NonEmpty.toList
                 |> List.filter (\car -> car.metaData.carNumber == "2")
                 |> List.head
                 |> Maybe.map

--- a/app/app/Shared.elm
+++ b/app/app/Shared.elm
@@ -16,6 +16,7 @@ import FatalError exposing (FatalError)
 import Html exposing (Html)
 import Html.Styled
 import Http
+import List.NonEmpty
 import Motorsport.Analysis as Analysis exposing (Analysis)
 import Motorsport.RaceControl as RaceControl
 import Pages.Flags
@@ -69,10 +70,10 @@ init :
     -> ( Model, Effect Msg )
 init flags maybePagePath =
     ( { eventSummary = { id = "", name = "", season = 0, date = "", jsonPath = "" }
-      , raceControl_F1 = RaceControl.empty
-      , raceControl = RaceControl.empty
-      , analysis_F1 = Analysis.finished RaceControl.empty
-      , analysis = Analysis.finished RaceControl.empty
+      , raceControl_F1 = RaceControl.placeholder
+      , raceControl = RaceControl.placeholder
+      , analysis_F1 = Analysis.finished RaceControl.placeholder
+      , analysis = Analysis.finished RaceControl.placeholder
       }
     , Effect.none
     )
@@ -108,7 +109,10 @@ update msg m =
         JsonLoaded (Ok decoded) ->
             let
                 rcNew =
-                    RaceControl.init (Preprocess_F1.preprocess decoded)
+                    Preprocess_F1.preprocess decoded
+                        |> List.NonEmpty.fromList
+                        |> Maybe.map RaceControl.init
+                        |> Maybe.withDefault RaceControl.placeholder
             in
             ( { m
                 | raceControl_F1 = rcNew
@@ -138,7 +142,10 @@ update msg m =
         JsonLoaded_Wec (Ok decoded) ->
             let
                 rcNew =
-                    RaceControl.init decoded.preprocessed
+                    decoded.preprocessed
+                        |> List.NonEmpty.fromList
+                        |> Maybe.map RaceControl.init
+                        |> Maybe.withDefault RaceControl.placeholder
 
                 modelEventSummary =
                     m.eventSummary
@@ -172,7 +179,10 @@ update msg m =
         JsonLoaded_FormulaE (Ok decoded) ->
             let
                 rcNew =
-                    RaceControl.init decoded.preprocessed
+                    decoded.preprocessed
+                        |> List.NonEmpty.fromList
+                        |> Maybe.map RaceControl.init
+                        |> Maybe.withDefault RaceControl.placeholder
 
                 modelEventSummary =
                     m.eventSummary

--- a/app/app/Shared.elm
+++ b/app/app/Shared.elm
@@ -16,7 +16,6 @@ import FatalError exposing (FatalError)
 import Html exposing (Html)
 import Html.Styled
 import Http
-import List.NonEmpty
 import Motorsport.Analysis as Analysis exposing (Analysis)
 import Motorsport.RaceControl as RaceControl
 import Pages.Flags
@@ -110,8 +109,7 @@ update msg m =
             let
                 rcNew =
                     Preprocess_F1.preprocess decoded
-                        |> List.NonEmpty.fromList
-                        |> Maybe.map RaceControl.init
+                        |> RaceControl.fromCars
                         |> Maybe.withDefault RaceControl.placeholder
             in
             ( { m
@@ -143,8 +141,7 @@ update msg m =
             let
                 rcNew =
                     decoded.preprocessed
-                        |> List.NonEmpty.fromList
-                        |> Maybe.map RaceControl.init
+                        |> RaceControl.fromCars
                         |> Maybe.withDefault RaceControl.placeholder
 
                 modelEventSummary =
@@ -180,8 +177,7 @@ update msg m =
             let
                 rcNew =
                     decoded.preprocessed
-                        |> List.NonEmpty.fromList
-                        |> Maybe.map RaceControl.init
+                        |> RaceControl.fromCars
                         |> Maybe.withDefault RaceControl.placeholder
 
                 modelEventSummary =

--- a/package/src/Motorsport/Analysis.elm
+++ b/package/src/Motorsport/Analysis.elm
@@ -1,11 +1,10 @@
 module Motorsport.Analysis exposing (Analysis, finished, fromRaceControl)
 
-import Dict exposing (Dict)
-import List.Extra
+import List.NonEmpty as NonEmpty exposing (NonEmpty)
 import Motorsport.Car exposing (Car)
 import Motorsport.Clock as Clock
 import Motorsport.Duration exposing (Duration)
-import Motorsport.Lap exposing (Lap, MiniSector(..), completedLapsAt)
+import Motorsport.Lap exposing (completedLapsAt)
 import Motorsport.Lap.Performance exposing (MiniSectorFastest, calculateMiniSectorFastest, findFastest, findFastestBy, findSlowest)
 
 
@@ -19,14 +18,15 @@ type alias Analysis =
     }
 
 
-fromRaceControl : { a | clock : Clock.Model, cars : List Car } -> Analysis
+fromRaceControl : { a | clock : Clock.Model, cars : NonEmpty Car } -> Analysis
 fromRaceControl { clock, cars } =
     let
         raceClock =
             { elapsed = Clock.getElapsed clock }
 
         completedLaps =
-            List.map (.laps >> completedLapsAt raceClock) cars
+            NonEmpty.toList cars
+                |> List.map (.laps >> completedLapsAt raceClock)
     in
     { fastestLapTime = completedLaps |> findFastest |> Maybe.map .time |> Maybe.withDefault 0
     , slowestLapTime = completedLaps |> findSlowest |> Maybe.map .time |> Maybe.withDefault 0
@@ -37,11 +37,12 @@ fromRaceControl { clock, cars } =
     }
 
 
-finished : { a | cars : List Car } -> Analysis
+finished : { a | cars : NonEmpty Car } -> Analysis
 finished { cars } =
     let
         laps =
-            List.map .laps cars
+            NonEmpty.toList cars
+                |> List.map .laps
     in
     { fastestLapTime = laps |> findFastest |> Maybe.map .time |> Maybe.withDefault 0
     , slowestLapTime = laps |> findSlowest |> Maybe.map .time |> Maybe.withDefault 0

--- a/package/src/Motorsport/Chart/GapChart.elm
+++ b/package/src/Motorsport/Chart/GapChart.elm
@@ -4,6 +4,7 @@ import Axis
 import Css exposing (Style, fill, hex, property)
 import Css.Global exposing (descendants, each, typeSelector)
 import Html.Styled exposing (Html, text)
+import List.NonEmpty as NonEmpty exposing (NonEmpty)
 import Motorsport.Analysis exposing (Analysis)
 import Motorsport.Chart.Fragments exposing (dotWithLabel, path)
 import Motorsport.Duration exposing (Duration)
@@ -83,17 +84,19 @@ view analysis { lapTotal, cars } =
         [ xAxis lapTotal
         , yAxis fastestLapTime
         , g [] <|
-            List.map
-                (\{ laps } ->
-                    dotHistory
-                        { x = .lap >> toFloat >> Scale.convert (xScale lapTotal)
-                        , y = (\{ lap, elapsed } -> toFloat elapsed - (toFloat (lap * fastestLapTime) * 1.02)) >> Scale.convert (yScale fastestLapTime)
-                        , color = "#000"
-                        , dotLabel = .lap >> String.fromInt
-                        }
-                        laps
-                )
-                cars
+            (cars
+                |> NonEmpty.toList
+                |> List.map
+                    (\{ laps } ->
+                        dotHistory
+                            { x = .lap >> toFloat >> Scale.convert (xScale lapTotal)
+                            , y = (\{ lap, elapsed } -> toFloat elapsed - (toFloat (lap * fastestLapTime) * 1.02)) >> Scale.convert (yScale fastestLapTime)
+                            , color = "#000"
+                            , dotLabel = .lap >> String.fromInt
+                            }
+                            laps
+                    )
+            )
         ]
 
 

--- a/package/src/Motorsport/Chart/LapTimeChart.elm
+++ b/package/src/Motorsport/Chart/LapTimeChart.elm
@@ -4,6 +4,7 @@ import Axis
 import Css exposing (Style, fill, hex, property)
 import Css.Global exposing (descendants, each, typeSelector)
 import Html.Styled exposing (Html)
+import List.NonEmpty as NonEmpty
 import Motorsport.Analysis exposing (Analysis)
 import Motorsport.Chart.Fragments exposing (dotWithLabel, path)
 import Motorsport.Duration exposing (Duration)
@@ -83,17 +84,19 @@ view analysis { lapTotal, cars } =
         [ xAxis lapTotal
         , yAxis fastestLapTime
         , g [] <|
-            List.map
-                (\{ laps } ->
-                    dotHistory
-                        { x = .lap >> toFloat >> Scale.convert (xScale lapTotal)
-                        , y = .time >> toFloat >> Scale.convert (yScale fastestLapTime)
-                        , color = "#000"
-                        , dotLabel = .lap >> String.fromInt
-                        }
-                        laps
-                )
-                cars
+            (cars
+                |> NonEmpty.toList
+                |> List.map
+                    (\{ laps } ->
+                        dotHistory
+                            { x = .lap >> toFloat >> Scale.convert (xScale lapTotal)
+                            , y = .time >> toFloat >> Scale.convert (yScale fastestLapTime)
+                            , color = "#000"
+                            , dotLabel = .lap >> String.fromInt
+                            }
+                            laps
+                    )
+            )
         ]
 
 

--- a/package/src/Motorsport/Chart/LapTimeChartsByDriver.elm
+++ b/package/src/Motorsport/Chart/LapTimeChartsByDriver.elm
@@ -5,6 +5,7 @@ import Css exposing (Style, fill, hex, listStyle, none, property, zero)
 import Css.Global exposing (descendants, each, typeSelector)
 import Html.Styled exposing (Html, li, p, text, ul)
 import Html.Styled.Attributes exposing (css)
+import List.NonEmpty as NonEmpty
 import Motorsport.Analysis exposing (Analysis)
 import Motorsport.Chart.Fragments exposing (dot, path)
 import Motorsport.Duration exposing (Duration)
@@ -88,23 +89,24 @@ view analysis { lapTotal, cars } =
             , Css.padding zero
             ]
         ]
-        (List.map
-            (\car ->
-                li [ css [ listStyle none ] ]
-                    [ p [] [ text car.metaData.carNumber ]
-                    , svg [ viewBox 0 0 w h ]
-                        [ xAxis lapTotal
-                        , yAxis fastestLapTime
-                        , dotHistory
-                            { x = .lap >> toFloat >> Scale.convert (xScale lapTotal)
-                            , y = .time >> toFloat >> Scale.convert (yScale fastestLapTime)
-                            , color = "#000"
-                            }
-                            car.laps
+        (cars
+            |> NonEmpty.toList
+            |> List.map
+                (\car ->
+                    li [ css [ listStyle none ] ]
+                        [ p [] [ text car.metaData.carNumber ]
+                        , svg [ viewBox 0 0 w h ]
+                            [ xAxis lapTotal
+                            , yAxis fastestLapTime
+                            , dotHistory
+                                { x = .lap >> toFloat >> Scale.convert (xScale lapTotal)
+                                , y = .time >> toFloat >> Scale.convert (yScale fastestLapTime)
+                                , color = "#000"
+                                }
+                                car.laps
+                            ]
                         ]
-                    ]
-            )
-            cars
+                )
         )
 
 

--- a/package/src/Motorsport/Chart/PositionHistory.elm
+++ b/package/src/Motorsport/Chart/PositionHistory.elm
@@ -6,6 +6,7 @@ import Css.Extra exposing (strokeWidth, svgPalette)
 import Css.Global exposing (descendants, each)
 import Css.Palette.Svg exposing (..)
 import Html.Styled exposing (Html)
+import List.NonEmpty as NonEmpty
 import Motorsport.Car exposing (Car)
 import Motorsport.Class as Class
 import Motorsport.Clock as Clock
@@ -100,6 +101,7 @@ view { clock, lapTotal, cars } =
         [ xAxis lapTotal
         , g []
             (cars
+                |> NonEmpty.toList
                 |> List.sortBy .startPosition
                 |> List.map
                     (\car ->
@@ -114,7 +116,7 @@ view { clock, lapTotal, cars } =
                         in
                         history
                             { x = toFloat >> Scale.convert (xScale lapTotal)
-                            , y = toFloat >> Scale.convert (yScale cars)
+                            , y = toFloat >> Scale.convert (yScale (NonEmpty.toList cars))
                             , svgPalette = Class.toStrokePalette class
                             , label = String.join " " [ carNumber, team ]
                             }

--- a/package/src/Motorsport/RaceControl.elm
+++ b/package/src/Motorsport/RaceControl.elm
@@ -1,4 +1,4 @@
-module Motorsport.RaceControl exposing (CarEventType(..), Event, EventType(..), Model, Msg(..), applyEvents, calcEvents, init, placeholder, update)
+module Motorsport.RaceControl exposing (CarEventType(..), Event, EventType(..), Model, Msg(..), applyEvents, calcEvents, fromCars, init, placeholder, update)
 
 import List.Extra
 import List.NonEmpty as NonEmpty exposing (NonEmpty)
@@ -52,6 +52,11 @@ placeholder =
             }
     in
     init (NonEmpty.singleton dummyCar)
+
+
+fromCars : List Car -> Maybe Model
+fromCars =
+    NonEmpty.fromList >> Maybe.map init
 
 
 init : NonEmpty Car -> Model

--- a/package/src/Motorsport/RaceControl.elm
+++ b/package/src/Motorsport/RaceControl.elm
@@ -166,7 +166,7 @@ update msg m =
                                 Clock.calcElapsed startedAt now splitTime
 
                             newClock =
-                                { lapCount = lapAt newElapsed (NonEmpty.toList m.cars |> List.map .laps)
+                                { lapCount = lapAt newElapsed (NonEmpty.map .laps m.cars)
                                 , elapsed = newElapsed
                                 }
                         in
@@ -215,7 +215,7 @@ update msg m =
                                     newElapsed =
                                         elapsed_ + (10 * 1000)
                                 in
-                                { lapCount = lapAt newElapsed lapTimes
+                                { lapCount = lapAt newElapsed (NonEmpty.map .laps m.cars)
                                 , elapsed = newElapsed
                                 }
 
@@ -370,9 +370,11 @@ applyEventToCar event car =
             }
 
 
-lapAt : Int -> List (List { a | lap : Int, elapsed : Duration }) -> Int
+lapAt : Int -> NonEmpty (List { a | lap : Int, elapsed : Duration }) -> Int
 lapAt elapsed lapTimes =
+    -- TODO: leaderのみを対象にする
     lapTimes
+        |> NonEmpty.toList
         |> List.filterMap
             (List.Extra.findMap
                 (\lap ->

--- a/package/src/Motorsport/RaceControl.elm
+++ b/package/src/Motorsport/RaceControl.elm
@@ -175,15 +175,12 @@ update msg m =
                             , lapCount = newClock.lapCount
                             , cars =
                                 m.cars
-                                    |> NonEmpty.toList
                                     |> applyEvents newElapsed m.events
-                                    |> List.sortWith
+                                    |> NonEmpty.sortWith
                                         (\a b ->
                                             Maybe.map2 (Lap.compareAt { elapsed = newClock.elapsed }) a.currentLap b.currentLap
                                                 |> Maybe.withDefault EQ
                                         )
-                                    |> NonEmpty.fromList
-                                    |> Maybe.withDefault m.cars
                         }
 
                     else
@@ -276,11 +273,8 @@ update msg m =
                 , lapCount = lapCount
                 , cars =
                     m.cars
-                        |> NonEmpty.toList
                         |> updateCars { elapsed = elapsed }
                         |> applyEvents elapsed m.events
-                        |> NonEmpty.fromList
-                        |> Maybe.withDefault m.cars
             }
 
 
@@ -288,17 +282,17 @@ type alias Clock =
     { elapsed : Duration }
 
 
-updateCars : Clock -> List Car -> List Car
+updateCars : Clock -> NonEmpty Car -> NonEmpty Car
 updateCars raceClock cars =
     cars
-        |> List.map
+        |> NonEmpty.map
             (\car ->
                 { car
                     | currentLap = Lap.findCurrentLap raceClock car.laps
                     , lastLap = Lap.findLastLapAt raceClock car.laps
                 }
             )
-        |> List.sortWith
+        |> NonEmpty.sortWith
             (\a b ->
                 Maybe.map2 (Lap.compareAt raceClock) a.currentLap b.currentLap
                     |> Maybe.withDefault EQ
@@ -319,7 +313,7 @@ isCarEvent { eventType } =
 
 {-| イベント情報に基づいて車両のステータスを更新する
 -}
-applyEvents : Duration -> List Event -> List Car -> List Car
+applyEvents : Duration -> List Event -> NonEmpty Car -> NonEmpty Car
 applyEvents currentElapsed events cars =
     let
         activeEvents =
@@ -329,7 +323,7 @@ applyEvents currentElapsed events cars =
             List.partition isCarEvent activeEvents
     in
     cars
-        |> List.map
+        |> NonEmpty.map
             (\car ->
                 let
                     carEvents =

--- a/package/src/Motorsport/RaceControl/ViewModel.elm
+++ b/package/src/Motorsport/RaceControl/ViewModel.elm
@@ -19,6 +19,7 @@ module Motorsport.RaceControl.ViewModel exposing
 
 import Dict exposing (Dict)
 import List.Extra
+import List.NonEmpty as NonEmpty exposing (NonEmpty)
 import Motorsport.Car exposing (Car, Status)
 import Motorsport.Class exposing (Class)
 import Motorsport.Clock as Clock
@@ -73,6 +74,7 @@ init { clock, lapCount, cars } =
 
         items =
             cars
+                |> NonEmpty.toList
                 |> List.indexedMap
                     (\index car ->
                         let
@@ -93,8 +95,8 @@ init { clock, lapCount, cars } =
                         , lap = lastLap.lap
                         , timing =
                             init_timing clock
-                                { leader = List.head cars
-                                , rival = List.Extra.getAt (index - 1) cars
+                                { leader = Just (NonEmpty.head cars)
+                                , rival = List.Extra.getAt (index - 1) (NonEmpty.toList cars)
                                 }
                                 car
                         , currentLap = car.currentLap
@@ -162,9 +164,10 @@ init_timing clock { leader, rival } car =
     }
 
 
-positionsInClassByCarNumber : List Car -> Dict String Int
+positionsInClassByCarNumber : NonEmpty Car -> Dict String Int
 positionsInClassByCarNumber cars =
     cars
+        |> NonEmpty.toList
         |> List.Extra.gatherEqualsBy (.metaData >> .class)
         |> List.concatMap
             (\( firstCar, restCars ) ->


### PR DESCRIPTION
This pull request introduces a significant refactor to the `Motorsport` module by replacing lists of cars with non-empty lists (`NonEmpty`) to ensure data integrity and simplify operations. It also includes updates to how `RaceControl` models are initialized and processed. Below is a summary of the most important changes grouped by theme.

### Transition to Non-Empty Lists
* Replaced `List` with `NonEmpty` for cars in the `Motorsport.Analysis`, `Motorsport.RaceControl`, and chart modules to enforce non-empty constraints. This includes updates to type signatures, such as `fromRaceControl` and `finished` in `Motorsport.Analysis` and `init` in `Motorsport.RaceControl`.

### Placeholder Model for Race Control
* Introduced a `placeholder` model in `Motorsport.RaceControl` to provide a default value for scenarios where no valid data is available.
* Added a `fromCars` function to convert a list of cars into a `Maybe Model`, ensuring safe initialization of race control models.

### Updates to Chart Rendering
* Modified chart modules (`GapChart`, `LapTimeChart`, `LapTimeChartsByDriver`, and `PositionHistory`) to handle `NonEmpty` lists of cars. This includes converting `NonEmpty` lists to regular lists before mapping operations.

### Refactor of Data Processing in `Shared.elm`
* Updated the `update` function in `Shared.elm` to use the new `RaceControl.fromCars` function for initializing race control models, with a fallback to the `placeholder` model when data is missing.

### Code Cleanup and Imports
* Added imports for `List.NonEmpty` across multiple files to support the transition to `NonEmpty` lists. Removed unused imports such as `List.Extra` and `Dict` where applicable.