### PR TITLE
feat: add `.itemsByClass` to `ViewModel`

### DIFF
--- a/app/app/Route/Debug.elm
+++ b/app/app/Route/Debug.elm
@@ -284,5 +284,5 @@ raceControlToLeaderboard { lapCount, cars } =
     , itemsByClass =
         sortedItems
             |> SortedList.gatherEqualsBy (.metaData >> .class)
-            |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
+            |> List.map (\( first, rest ) -> ( first.metaData.class, Ordering.byPosition (first :: SortedList.toList rest) ))
     }

--- a/app/app/Route/Debug.elm
+++ b/app/app/Route/Debug.elm
@@ -281,4 +281,8 @@ raceControlToLeaderboard { lapCount, cars } =
     in
     { leadLapNumber = leadLapNumber
     , items = sortedItems
+    , itemsByClass =
+        sortedItems
+            |> SortedList.gatherEqualsBy (.metaData >> .class)
+            |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
     }

--- a/package/src/Motorsport/RaceControl/ViewModel.elm
+++ b/package/src/Motorsport/RaceControl/ViewModel.elm
@@ -35,6 +35,7 @@ import SortedList exposing (SortedList)
 type alias ViewModel =
     { leadLapNumber : Int
     , items : SortedList ByPosition ViewModelItem
+    , itemsByClass : List ( Class, List ViewModelItem )
     }
 
 
@@ -106,9 +107,16 @@ init { clock, lapCount, cars } =
                         , history = completedLapsAt raceClock car.laps
                         }
                     )
+
+        sortedItems =
+            Ordering.byPosition items
     in
     { leadLapNumber = lapCount
-    , items = Ordering.byPosition items
+    , items = sortedItems
+    , itemsByClass =
+        sortedItems
+            |> SortedList.gatherEqualsBy (.metaData >> .class)
+            |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
     }
 
 

--- a/package/src/Motorsport/RaceControl/ViewModel.elm
+++ b/package/src/Motorsport/RaceControl/ViewModel.elm
@@ -35,7 +35,7 @@ import SortedList exposing (SortedList)
 type alias ViewModel =
     { leadLapNumber : Int
     , items : SortedList ByPosition ViewModelItem
-    , itemsByClass : List ( Class, List ViewModelItem )
+    , itemsByClass : List ( Class, SortedList ByPosition ViewModelItem )
     }
 
 
@@ -116,7 +116,7 @@ init { clock, lapCount, cars } =
     , itemsByClass =
         sortedItems
             |> SortedList.gatherEqualsBy (.metaData >> .class)
-            |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
+            |> List.map (\( first, rest ) -> ( first.metaData.class, Ordering.byPosition (first :: SortedList.toList rest) ))
     }
 
 

--- a/package/src/Motorsport/Widget/BestLapTimes.elm
+++ b/package/src/Motorsport/Widget/BestLapTimes.elm
@@ -8,6 +8,7 @@ import Motorsport.Class exposing (Class)
 import Motorsport.Duration as Duration exposing (Duration)
 import Motorsport.RaceControl.ViewModel exposing (ViewModel)
 import Motorsport.Widget as Widget
+import SortedList
 
 
 type alias CarLapData =
@@ -46,7 +47,7 @@ processClassBestTimes viewModel =
             (\( class, cars ) ->
                 { class = class
                 , cars =
-                    cars
+                    SortedList.toList cars
                         |> List.sortBy (.lastLap >> Maybe.map .best >> Maybe.withDefault 999999)
                         |> List.take 3
                         |> List.map

--- a/package/src/Motorsport/Widget/BestLapTimes.elm
+++ b/package/src/Motorsport/Widget/BestLapTimes.elm
@@ -8,7 +8,6 @@ import Motorsport.Class exposing (Class)
 import Motorsport.Duration as Duration exposing (Duration)
 import Motorsport.RaceControl.ViewModel exposing (ViewModel)
 import Motorsport.Widget as Widget
-import SortedList
 
 
 type alias CarLapData =
@@ -42,9 +41,7 @@ view analysis viewModel =
 
 processClassBestTimes : ViewModel -> List ClassData
 processClassBestTimes viewModel =
-    viewModel.items
-        |> SortedList.gatherEqualsBy (.metaData >> .class)
-        |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
+    viewModel.itemsByClass
         |> List.map
             (\( class, cars ) ->
                 { class = class

--- a/package/src/Motorsport/Widget/LapTimeProgression.elm
+++ b/package/src/Motorsport/Widget/LapTimeProgression.elm
@@ -17,6 +17,7 @@ import Motorsport.Widget as Widget
 import Path
 import Scale exposing (ContinuousScale)
 import Shape
+import SortedList
 import Svg.Styled exposing (Svg, circle, fromUnstyled, g, svg)
 import Svg.Styled.Attributes as SvgAttr
 import TypedSvg.Attributes as TA
@@ -85,7 +86,7 @@ processClassProgressionData clock viewModel =
             (\( class, carsInClass ) ->
                 let
                     cars =
-                        carsInClass
+                        SortedList.toList carsInClass
                             |> List.map
                                 (\car ->
                                     let

--- a/package/src/Motorsport/Widget/LapTimeProgression.elm
+++ b/package/src/Motorsport/Widget/LapTimeProgression.elm
@@ -17,7 +17,6 @@ import Motorsport.Widget as Widget
 import Path
 import Scale exposing (ContinuousScale)
 import Shape
-import SortedList
 import Svg.Styled exposing (Svg, circle, fromUnstyled, g, svg)
 import Svg.Styled.Attributes as SvgAttr
 import TypedSvg.Attributes as TA
@@ -81,9 +80,7 @@ view clock viewModel =
 
 processClassProgressionData : Clock.Model -> ViewModel -> List ClassProgressionData
 processClassProgressionData clock viewModel =
-    viewModel.items
-        |> SortedList.gatherEqualsBy (.metaData >> .class)
-        |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
+    viewModel.itemsByClass
         |> List.map
             (\( class, carsInClass ) ->
                 let

--- a/package/src/Motorsport/Widget/PositionProgression.elm
+++ b/package/src/Motorsport/Widget/PositionProgression.elm
@@ -105,7 +105,7 @@ processClassPositionData clock viewModel =
             (\( class, carsInClass ) ->
                 let
                     cars =
-                        carsInClass
+                        SortedList.toList carsInClass
                             |> List.map
                                 (\car ->
                                     let
@@ -121,7 +121,7 @@ processClassPositionData clock viewModel =
                 in
                 { class = class
                 , cars = cars
-                , carCount = List.length carsInClass
+                , carCount = SortedList.length carsInClass
                 }
             )
         |> List.filter (\classData -> List.length classData.cars > 0)

--- a/package/src/Motorsport/Widget/PositionProgression.elm
+++ b/package/src/Motorsport/Widget/PositionProgression.elm
@@ -100,9 +100,7 @@ processClassPositionData clock viewModel =
                 |> Maybe.map .lap
                 |> Maybe.withDefault 1
     in
-    viewModel.items
-        |> SortedList.gatherEqualsBy (.metaData >> .class)
-        |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
+    viewModel.itemsByClass
         |> List.map
             (\( class, carsInClass ) ->
                 let

--- a/package/tests/Motorsport/RaceControl/ViewModelTest.elm
+++ b/package/tests/Motorsport/RaceControl/ViewModelTest.elm
@@ -8,6 +8,7 @@ import Motorsport.Duration exposing (Duration)
 import Motorsport.Gap as Gap exposing (Gap(..))
 import Motorsport.Ordering as Ordering
 import Motorsport.RaceControl.ViewModel as ViewModel exposing (MetaData, Timing, ViewModelItem)
+import SortedList
 import Test exposing (Test, describe, test)
 
 
@@ -24,9 +25,16 @@ suite =
                             , createViewModelItem 3 "3" 1501 -- 1.501s - not close
                             ]
 
+                        sortedItems =
+                            Ordering.byPosition items
+
                         viewModel =
                             { leadLapNumber = List.head items |> Maybe.map .lap |> Maybe.withDefault 0
-                            , items = Ordering.byPosition items
+                            , items = sortedItems
+                            , itemsByClass =
+                                sortedItems
+                                    |> SortedList.gatherEqualsBy (.metaData >> .class)
+                                    |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
                             }
                     in
                     ViewModel.groupCarsByCloseIntervals viewModel
@@ -44,9 +52,16 @@ suite =
                             , createViewModelItem 3 "3" 1200 -- Continues Group 2
                             ]
 
+                        sortedItems =
+                            Ordering.byPosition items
+
                         viewModel =
                             { leadLapNumber = List.head items |> Maybe.map .lap |> Maybe.withDefault 0
-                            , items = Ordering.byPosition items
+                            , items = sortedItems
+                            , itemsByClass =
+                                sortedItems
+                                    |> SortedList.gatherEqualsBy (.metaData >> .class)
+                                    |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
                             }
                     in
                     ViewModel.groupCarsByCloseIntervals viewModel
@@ -64,9 +79,16 @@ suite =
                             , createViewModelItemWithGap 3 "3" (Gap.Laps 1)
                             ]
 
+                        sortedItems =
+                            Ordering.byPosition items
+
                         viewModel =
                             { leadLapNumber = List.head items |> Maybe.map .lap |> Maybe.withDefault 0
-                            , items = Ordering.byPosition items
+                            , items = sortedItems
+                            , itemsByClass =
+                                sortedItems
+                                    |> SortedList.gatherEqualsBy (.metaData >> .class)
+                                    |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
                             }
                     in
                     ViewModel.groupCarsByCloseIntervals viewModel

--- a/package/tests/Motorsport/RaceControl/ViewModelTest.elm
+++ b/package/tests/Motorsport/RaceControl/ViewModelTest.elm
@@ -34,7 +34,7 @@ suite =
                             , itemsByClass =
                                 sortedItems
                                     |> SortedList.gatherEqualsBy (.metaData >> .class)
-                                    |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
+                                    |> List.map (\( first, rest ) -> ( first.metaData.class, Ordering.byPosition (first :: SortedList.toList rest) ))
                             }
                     in
                     ViewModel.groupCarsByCloseIntervals viewModel
@@ -61,7 +61,7 @@ suite =
                             , itemsByClass =
                                 sortedItems
                                     |> SortedList.gatherEqualsBy (.metaData >> .class)
-                                    |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
+                                    |> List.map (\( first, rest ) -> ( first.metaData.class, Ordering.byPosition (first :: SortedList.toList rest) ))
                             }
                     in
                     ViewModel.groupCarsByCloseIntervals viewModel
@@ -88,7 +88,7 @@ suite =
                             , itemsByClass =
                                 sortedItems
                                     |> SortedList.gatherEqualsBy (.metaData >> .class)
-                                    |> List.map (\( first, rest ) -> ( first.metaData.class, first :: SortedList.toList rest ))
+                                    |> List.map (\( first, rest ) -> ( first.metaData.class, Ordering.byPosition (first :: SortedList.toList rest) ))
                             }
                     in
                     ViewModel.groupCarsByCloseIntervals viewModel


### PR DESCRIPTION
This pull request introduces a new feature to group race control items by their class and updates various components to utilize this grouping.

### Enhancements to ViewModel:

- Added a new `itemsByClass` property to the `ViewModel` type, which groups race control items by their class using `SortedList.gatherEqualsBy` and sorts them by position. (`package/src/Motorsport/RaceControl/ViewModel.elm` - [[1]](diffhunk://#diff-0881a657e75d9a2cea41588daf1083c50f2fd0967a08beffe66bd21847c289a9R38) [[2]](diffhunk://#diff-0881a657e75d9a2cea41588daf1083c50f2fd0967a08beffe66bd21847c289a9R110-R119)

### Refactoring in Widgets:

- Updated `BestLapTimes`, `LapTimeProgression`, and `PositionProgression` widgets to use the `itemsByClass` property instead of manually grouping and sorting items by class. This simplifies the logic and ensures consistency. (`package/src/Motorsport/Widget/BestLapTimes.elm` - [[1]](diffhunk://#diff-6bf5e04cfded4804010b50dc4db96df9a7a863c758ee695ad02b6cb80a74d7acL45-R50) `package/src/Motorsport/Widget/LapTimeProgression.elm` - [[2]](diffhunk://#diff-bc090fa099f8d19e3753590bc8a54405b7305855bd5716d6c8e5bc5e5b878bfaL84-R89) `package/src/Motorsport/Widget/PositionProgression.elm` - [[3]](diffhunk://#diff-27cda0e5f715b4e649fe5a999f9c12374d57c9e451479e6a33ab5c6da3e06f79L103-R108) [[4]](diffhunk://#diff-27cda0e5f715b4e649fe5a999f9c12374d57c9e451479e6a33ab5c6da3e06f79L126-R124)

### Updates to Tests:

- Refactored tests in `ViewModelTest` to accommodate the new `itemsByClass` property, ensuring proper grouping and sorting of race control items during testing. (`package/tests/Motorsport/RaceControl/ViewModelTest.elm` - [[1]](diffhunk://#diff-d8d51b82bc36280431909edebcbc12b060d1c43c18fece85118ff20f504413f4R11) [[2]](diffhunk://#diff-d8d51b82bc36280431909edebcbc12b060d1c43c18fece85118ff20f504413f4R28-R37) [[3]](diffhunk://#diff-d8d51b82bc36280431909edebcbc12b060d1c43c18fece85118ff20f504413f4R55-R64) [[4]](diffhunk://#diff-d8d51b82bc36280431909edebcbc12b060d1c43c18fece85118ff20f504413f4R82-R91)

### Miscellaneous Improvements:

- Introduced `sortedItems` as an intermediate variable in multiple places to avoid repetitive calls to `Ordering.byPosition` and improve readability. (`app/app/Route/Debug.elm` - [[1]](diffhunk://#diff-a959ef857f0c58013cc8364303c325c8082b34654bd717692755348393de4639R284-R287) `package/src/Motorsport/RaceControl/ViewModel.elm` - [[2]](diffhunk://#diff-0881a657e75d9a2cea41588daf1083c50f2fd0967a08beffe66bd21847c289a9R110-R119)

These changes enhance maintainability, reduce code duplication, and improve the organization of race control data across the application.