### PR TITLE
env: Rust formatter and linter

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -18,6 +18,7 @@
       "Bash(cargo build:*)",
       "Bash(cargo test:*)",
       "Bash(cargo run:*)",
+      "Bash(cargo fmt:*)",
       "WebFetch(domain:docs.anthropic.com)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:package.elm-lang.org)"

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -19,6 +19,7 @@
       "Bash(cargo test:*)",
       "Bash(cargo run:*)",
       "Bash(cargo fmt:*)",
+      "Bash(cargo clippy:*)",
       "WebFetch(domain:docs.anthropic.com)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:package.elm-lang.org)"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,7 @@
 FROM rust:1.88-bookworm AS rust-stage
 RUN apt-get update && apt-get install -y build-essential pkg-config libssl-dev \
     && rm -rf /var/lib/apt/lists/* \
+    && rustup component add rustfmt \
     && cargo install cargo-watch cargo-expand
 
 # Stage 2: Node.js with latest npm

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,7 +4,7 @@
 FROM rust:1.88-bookworm AS rust-stage
 RUN apt-get update && apt-get install -y build-essential pkg-config libssl-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && rustup component add rustfmt \
+    && rustup component add rustfmt clippy \
     && cargo install cargo-watch cargo-expand
 
 # Stage 2: Node.js with latest npm

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,3 +1,10 @@
 [workspace]
 resolver = "3"
 members = ["cli", "motorsport"]
+
+[workspace.package]
+edition = "2021"
+
+[workspace.dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["cli", "motorsport"]
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 
 [workspace.dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/cli/cli/Cargo.toml
+++ b/cli/cli/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "cli"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 [dependencies]
 motorsport = { path = "../motorsport" }
 csv = "1.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -19,7 +19,7 @@ impl Config {
                 if Path::new(&file).exists() {
                     Ok(file)
                 } else {
-                    Err(format!("Input file does not exist: {}", file).into())
+                    Err(format!("Input file does not exist: {file}").into())
                 }
             })?;
 

--- a/cli/cli/src/config.rs
+++ b/cli/cli/src/config.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use std::error::Error;
+use std::path::Path;
 
 #[derive(Debug)]
 pub struct Config {
@@ -47,7 +47,10 @@ mod tests {
         let input_path = temp_dir.path().join("input.csv");
         let output_path = temp_dir.path().join("output.json");
 
-        File::create(&input_path).unwrap().write_all(b"test").unwrap();
+        File::create(&input_path)
+            .unwrap()
+            .write_all(b"test")
+            .unwrap();
 
         let args = vec![
             "program".to_string(),
@@ -58,7 +61,10 @@ mod tests {
 
         let config = Config::build(args.into_iter()).unwrap();
         assert_eq!(config.input_file, input_path.to_string_lossy().to_string());
-        assert_eq!(config.output_file, Some(output_path.to_string_lossy().to_string()));
+        assert_eq!(
+            config.output_file,
+            Some(output_path.to_string_lossy().to_string())
+        );
         assert_eq!(config.event_name, Some("test_event".to_string()));
     }
 
@@ -71,10 +77,7 @@ mod tests {
 
     #[test]
     fn config_build_nonexistent_file() {
-        let args = vec![
-            "program".to_string(),
-            "nonexistent.csv".to_string(),
-        ];
+        let args = vec!["program".to_string(), "nonexistent.csv".to_string()];
         let result = Config::build(args.into_iter());
         assert!(result.is_err());
     }

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -1,14 +1,13 @@
 use std::error::Error;
 use std::fs;
 
-pub mod preprocess;
-pub mod output;
 pub mod config;
+pub mod output;
+pub mod preprocess;
 
-pub use preprocess::{parse_laps_from_csv, group_laps_by_car, LapWithMetadata};
-pub use output::{Output, create_output};
 pub use config::Config;
-
+pub use output::{create_output, Output};
+pub use preprocess::{group_laps_by_car, parse_laps_from_csv, LapWithMetadata};
 
 pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
     let csv_content = fs::read_to_string(&config.input_file)
@@ -20,7 +19,7 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
 
     let event_name = config.event_name.as_deref().unwrap_or("test_event");
     let output = create_output(event_name, &laps_with_metadata, &cars);
-    
+
     let json = serde_json::to_string_pretty(&output)
         .map_err(|e| format!("Failed to serialize output to JSON: {}", e))?;
 

--- a/cli/cli/src/lib.rs
+++ b/cli/cli/src/lib.rs
@@ -21,12 +21,12 @@ pub fn run(config: Config) -> Result<(), Box<dyn Error>> {
     let output = create_output(event_name, &laps_with_metadata, &cars);
 
     let json = serde_json::to_string_pretty(&output)
-        .map_err(|e| format!("Failed to serialize output to JSON: {}", e))?;
+        .map_err(|e| format!("Failed to serialize output to JSON: {e}"))?;
 
     let output_path = config.output_file.as_deref().unwrap_or("test.json");
     fs::write(output_path, &json)
-        .map_err(|e| format!("Failed to write output file '{}': {}", output_path, e))?;
+        .map_err(|e| format!("Failed to write output file '{output_path}': {e}"))?;
 
-    println!("Wrote JSON to {}", output_path);
+    println!("Wrote JSON to {output_path}");
     Ok(())
 }

--- a/cli/cli/src/output.rs
+++ b/cli/cli/src/output.rs
@@ -251,7 +251,7 @@ mod tests {
         if let Value::Number(n) = result {
             assert!((n.as_f64().unwrap() - 184.3).abs() < 0.001);
         } else {
-            panic!("Expected number, got {:?}", result);
+            panic!("Expected number, got {result:?}");
         }
     }
 
@@ -271,10 +271,7 @@ mod tests {
             assert_eq!(
                 result,
                 serde_json::Value::String(expected.to_string()),
-                "Expected '{}' to be formatted as '{}', but got: {:?}",
-                input,
-                expected,
-                result
+                "Expected '{input}' to be formatted as '{expected}', but got: {result:?}"
             );
         }
     }

--- a/cli/cli/src/output.rs
+++ b/cli/cli/src/output.rs
@@ -1,5 +1,5 @@
+use motorsport::{duration, Car, Driver};
 use serde::{Serialize, Serializer};
-use motorsport::{Car, duration, Driver};
 
 use crate::preprocess::LapWithMetadata;
 
@@ -122,7 +122,6 @@ pub struct PreprocessedCar {
     pub last_lap: Option<PreprocessedLap>,
 }
 
-
 /// Preprocessed lap format (車両内のlaps配列の要素)
 #[derive(Debug, Serialize)]
 pub struct PreprocessedLap {
@@ -160,57 +159,65 @@ pub fn create_output(
 
 /// LapWithMetadata から RawLap への変換
 fn raw_laps_from(laps_with_metadata: &[LapWithMetadata]) -> Vec<RawLap> {
-    laps_with_metadata.iter().map(|lap_meta| {
-        let lap = &lap_meta.lap;
-        let meta = &lap_meta.metadata;
+    laps_with_metadata
+        .iter()
+        .map(|lap_meta| {
+            let lap = &lap_meta.lap;
+            let meta = &lap_meta.metadata;
 
-        RawLap {
-            car_number: lap.car_number.clone(),
-            driver_number: lap_meta.csv_data.driver_number,
-            lap_number: lap.lap,
-            lap_time: duration::to_string(lap.time),
-            lap_improvement: lap_meta.csv_data.lap_improvement,
-            crossing_finish_line_in_pit: lap_meta.csv_data.crossing_finish_line_in_pit.clone(),
-            s1: format_sector_time(&lap_meta.csv_data.s1_raw, lap.sector_1),
-            s1_improvement: lap_meta.csv_data.s1_improvement,
-            s2: format_sector_time(&lap_meta.csv_data.s2_raw, lap.sector_2),
-            s2_improvement: lap_meta.csv_data.s2_improvement,
-            s3: format_sector_time(&lap_meta.csv_data.s3_raw, lap.sector_3),
-            s3_improvement: lap_meta.csv_data.s3_improvement,
-            kph: (lap_meta.csv_data.kph * 10.0).round() / 10.0,
-            elapsed: duration::to_string(lap.elapsed),
-            hour: lap_meta.csv_data.hour.clone(),
-            top_speed: lap_meta.csv_data.top_speed.clone().unwrap_or_default(),
-            driver_name: lap.driver.clone(),
-            pit_time: lap_meta.csv_data.pit_time.map_or_else(String::new, duration::to_string),
-            class: meta.class.clone(),
-            group: meta.group.clone(),
-            team: meta.team.clone(),
-            manufacturer: meta.manufacturer.clone(),
-        }
-    }).collect()
+            RawLap {
+                car_number: lap.car_number.clone(),
+                driver_number: lap_meta.csv_data.driver_number,
+                lap_number: lap.lap,
+                lap_time: duration::to_string(lap.time),
+                lap_improvement: lap_meta.csv_data.lap_improvement,
+                crossing_finish_line_in_pit: lap_meta.csv_data.crossing_finish_line_in_pit.clone(),
+                s1: format_sector_time(&lap_meta.csv_data.s1_raw, lap.sector_1),
+                s1_improvement: lap_meta.csv_data.s1_improvement,
+                s2: format_sector_time(&lap_meta.csv_data.s2_raw, lap.sector_2),
+                s2_improvement: lap_meta.csv_data.s2_improvement,
+                s3: format_sector_time(&lap_meta.csv_data.s3_raw, lap.sector_3),
+                s3_improvement: lap_meta.csv_data.s3_improvement,
+                kph: (lap_meta.csv_data.kph * 10.0).round() / 10.0,
+                elapsed: duration::to_string(lap.elapsed),
+                hour: lap_meta.csv_data.hour.clone(),
+                top_speed: lap_meta.csv_data.top_speed.clone().unwrap_or_default(),
+                driver_name: lap.driver.clone(),
+                pit_time: lap_meta
+                    .csv_data
+                    .pit_time
+                    .map_or_else(String::new, duration::to_string),
+                class: meta.class.clone(),
+                group: meta.group.clone(),
+                team: meta.team.clone(),
+                manufacturer: meta.manufacturer.clone(),
+            }
+        })
+        .collect()
 }
 
 /// Car から PreprocessedCar への変換
 fn preprocessed_cars_from(cars: &[Car]) -> Vec<PreprocessedCar> {
-    cars.iter().map(|car| {
-        let drivers = car.meta_data.drivers.clone();
+    cars.iter()
+        .map(|car| {
+            let drivers = car.meta_data.drivers.clone();
 
-        let laps = car.laps.iter().map(lap_to_preprocessed).collect();
+            let laps = car.laps.iter().map(lap_to_preprocessed).collect();
 
-        PreprocessedCar {
-            car_number: car.meta_data.car_number.clone(),
-            drivers,
-            class: car.meta_data.class.to_string().to_string(),
-            group: car.meta_data.group.clone(),
-            team: car.meta_data.team.clone(),
-            manufacturer: car.meta_data.manufacturer.clone(),
-            start_position: car.start_position,
-            laps,
-            current_lap: None,
-            last_lap: None,
-        }
-    }).collect()
+            PreprocessedCar {
+                car_number: car.meta_data.car_number.clone(),
+                drivers,
+                class: car.meta_data.class.to_string().to_string(),
+                group: car.meta_data.group.clone(),
+                team: car.meta_data.team.clone(),
+                manufacturer: car.meta_data.manufacturer.clone(),
+                start_position: car.start_position,
+                laps,
+                current_lap: None,
+                last_lap: None,
+            }
+        })
+        .collect()
 }
 
 /// Event name mapping
@@ -234,11 +241,11 @@ mod tests {
     #[test]
     fn test_serialize_speed() {
         use serde_json::Value;
-        
+
         // 整数値: .0を除去
         let result = serialize_speed(&186.0, serde_json::value::Serializer).unwrap();
         assert_eq!(result, Value::Number(186.into()));
-        
+
         // 小数値: そのまま保持
         let result = serialize_speed(&184.3, serde_json::value::Serializer).unwrap();
         if let Value::Number(n) = result {
@@ -251,18 +258,24 @@ mod tests {
     #[test]
     fn test_serialize_top_speed() {
         use serde_json::value::Serializer;
-        
+
         let test_cases = vec![
-            ("300.0", "300"),        // .0除去
-            ("288.8", "288.8"),      // 小数点保持
-            ("", ""),                // 空文字列保持
-            ("invalid", "invalid"),  // 不正値はそのまま
+            ("300.0", "300"),       // .0除去
+            ("288.8", "288.8"),     // 小数点保持
+            ("", ""),               // 空文字列保持
+            ("invalid", "invalid"), // 不正値はそのまま
         ];
 
         for (input, expected) in test_cases {
             let result = serialize_top_speed(input, Serializer).unwrap();
-            assert_eq!(result, serde_json::Value::String(expected.to_string()),
-                "Expected '{}' to be formatted as '{}', but got: {:?}", input, expected, result);
+            assert_eq!(
+                result,
+                serde_json::Value::String(expected.to_string()),
+                "Expected '{}' to be formatted as '{}', but got: {:?}",
+                input,
+                expected,
+                result
+            );
         }
     }
 

--- a/cli/motorsport/Cargo.toml
+++ b/cli/motorsport/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "motorsport"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 [dependencies]
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/cli/motorsport/src/car.rs
+++ b/cli/motorsport/src/car.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{Class, Driver};
 use crate::lap::Lap;
+use crate::{Class, Driver};
 
 /// 車両情報（ElmのCar型と互換）
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -16,11 +16,7 @@ pub struct Car {
 
 impl Car {
     /// 新しい車両を作成
-    pub fn new(
-        meta_data: MetaData,
-        start_position: i32,
-        laps: Vec<Lap>,
-    ) -> Self {
+    pub fn new(meta_data: MetaData, start_position: i32, laps: Vec<Lap>) -> Self {
         Car {
             meta_data,
             start_position,
@@ -204,9 +200,7 @@ mod tests {
 
     #[test]
     fn test_car_json_serialization() {
-        let drivers = vec![
-            Driver::new("Will STEVENS".to_string(), true),
-        ];
+        let drivers = vec![Driver::new("Will STEVENS".to_string(), true)];
 
         let metadata = MetaData::new(
             "12".to_string(),

--- a/cli/motorsport/src/class.rs
+++ b/cli/motorsport/src/class.rs
@@ -91,7 +91,10 @@ mod tests {
         assert_eq!(Class::from_string("LMGTE Pro"), Some(Class::LMGTEPro));
         assert_eq!(Class::from_string("LMGTE Am"), Some(Class::LMGTEAm));
         assert_eq!(Class::from_string("LMGT3"), Some(Class::LMGT3));
-        assert_eq!(Class::from_string("INNOVATIVE CAR"), Some(Class::InnovativeCar));
+        assert_eq!(
+            Class::from_string("INNOVATIVE CAR"),
+            Some(Class::InnovativeCar)
+        );
 
         // 不正なケース
         assert_eq!(Class::from_string("UNKNOWN"), None);

--- a/cli/motorsport/src/driver.rs
+++ b/cli/motorsport/src/driver.rs
@@ -24,7 +24,7 @@ pub fn find_current_driver(drivers: &[Driver]) -> Option<&Driver> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Driver, find_current_driver};
+    use super::{find_current_driver, Driver};
 
     #[test]
     fn find_current_driver_() {

--- a/cli/motorsport/src/duration.rs
+++ b/cli/motorsport/src/duration.rs
@@ -6,7 +6,9 @@ pub fn from_string(s: &str) -> Option<Duration> {
     let parts: Vec<&str> = s.split(':').collect();
 
     let convert_seconds = |s: &str| -> Option<u32> {
-        s.parse::<f64>().ok().map(|sec| (sec * 1000.0).round() as u32)
+        s.parse::<f64>()
+            .ok()
+            .map(|sec| (sec * 1000.0).round() as u32)
     };
 
     match parts.as_slice() {
@@ -41,7 +43,10 @@ pub fn to_string(ms: Duration) -> String {
             let hours = s / 3600;
             let minutes = (s % 3600) / 60;
             let seconds = s % 60;
-            format!("{}:{:02}:{:02}.{:03}", hours, minutes, seconds, milliseconds)
+            format!(
+                "{}:{:02}:{:02}.{:03}",
+                hours, minutes, seconds, milliseconds
+            )
         }
     }
 }

--- a/cli/motorsport/src/duration.rs
+++ b/cli/motorsport/src/duration.rs
@@ -33,19 +33,18 @@ pub fn to_string(ms: Duration) -> String {
     let milliseconds = ms % 1000;
 
     match ms / 1000 {
-        s if s < 60 => format!("{}.{:03}", s, milliseconds),
+        s if s < 60 => format!("{s}.{milliseconds:03}"),
         s if s < 3600 => {
             let minutes = s / 60;
             let seconds = s % 60;
-            format!("{}:{:02}.{:03}", minutes, seconds, milliseconds)
+            format!("{minutes}:{seconds:02}.{milliseconds:03}")
         }
         s => {
             let hours = s / 3600;
             let minutes = (s % 3600) / 60;
             let seconds = s % 60;
             format!(
-                "{}:{:02}:{:02}.{:03}",
-                hours, minutes, seconds, milliseconds
+                "{hours}:{minutes:02}:{seconds:02}.{milliseconds:03}"
             )
         }
     }

--- a/cli/motorsport/src/lap.rs
+++ b/cli/motorsport/src/lap.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use crate::Duration;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Lap {

--- a/cli/motorsport/src/lib.rs
+++ b/cli/motorsport/src/lib.rs
@@ -1,11 +1,11 @@
+pub mod car;
 pub mod class;
 pub mod driver;
 pub mod duration;
-pub mod car;
 pub mod lap;
 
+pub use car::{Car, CarNumber, MetaData, Status};
 pub use class::Class;
 pub use driver::Driver;
 pub use duration::Duration;
-pub use car::{Car, MetaData, Status, CarNumber};
 pub use lap::Lap;


### PR DESCRIPTION
This pull request introduces multiple changes across the Rust CLI project to enhance functionality. Key updates include adopting the 2024 edition of Rust, refactoring code for clarity, and adding new dependencies for formatting and linting. 

### Project Configuration Updates:
* Updated `.claude/settings.local.json` to include `cargo fmt` and `cargo clippy` commands for formatting and linting.
* Modified `.devcontainer/Dockerfile` to install `rustfmt` and `clippy` components for code formatting and linting during development.
* Updated `cli/Cargo.toml` to use the Rust 2024 edition and added `serde` and `serde_json` as workspace dependencies.

### Code Modernization:
* Replaced string interpolation with Rust's `{}` formatting syntax in error messages and logs for better readability. [[1]](diffhunk://#diff-870de6f95c587f0dc19fe60d71aa36fda1522d763d98c7a2b177a5a4f5970552L22-R22) [[2]](diffhunk://#diff-934976293040055b9f28a6c42ae3e4d21c4f7894be3ee657b3ec9853953a0d41L25-R30) [[3]](diffhunk://#diff-484344090873670d01294b25d412a7510e769a2acd2d91e660291148d7f79944L247-R254)
* Improved formatting of test code and function arguments by splitting long lines into multiple lines for better readability. [[1]](diffhunk://#diff-870de6f95c587f0dc19fe60d71aa36fda1522d763d98c7a2b177a5a4f5970552L50-R53) [[2]](diffhunk://#diff-870de6f95c587f0dc19fe60d71aa36fda1522d763d98c7a2b177a5a4f5970552L61-R67) [[3]](diffhunk://#diff-dc1f7d284f17e3a0d8c03b3e325bba8e683f67a7c1f5b7120847178c9fa9c04dL424-R448)