### PR TITLE
feat: add `currentDriver` to `Car` type

### DIFF
--- a/app/app/Route/Debug.elm
+++ b/app/app/Route/Debug.elm
@@ -11,6 +11,7 @@ import Html.Styled.Events exposing (onClick, onInput)
 import List.NonEmpty as NonEmpty
 import Motorsport.Analysis exposing (Analysis)
 import Motorsport.Clock as Clock
+import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration as Duration
 import Motorsport.Gap as Gap
 import Motorsport.Leaderboard as Leaderboard exposing (bestTimeColumn, carNumberColumn_Wec, customColumn, driverAndTeamColumn_Wec, initialSort, intColumn, lastLapColumn_F1, sectorTimeColumn)
@@ -177,7 +178,7 @@ config analysis =
     , columns =
         [ intColumn { label = "", getter = .position }
         , carNumberColumn_Wec 2025 { getter = .metaData }
-        , driverAndTeamColumn_Wec { getter = .metaData }
+        , driverAndTeamColumn_Wec { getter = \item -> { metaData = item.metaData, currentDriver = item.currentDriver } }
         , intColumn { label = "Lap", getter = .lap }
         , sectorTimeColumn
             { label = "S1"
@@ -270,6 +271,7 @@ raceControlToLeaderboard { lapCount, cars } =
                                     , currentLap = Just lap
                                     , lastLap = Just lap
                                     , history = []
+                                    , currentDriver = Just (Driver lap.driver)
                                     }
                                 )
                     )

--- a/app/app/Route/Debug.elm
+++ b/app/app/Route/Debug.elm
@@ -173,12 +173,12 @@ view app { analysis, raceControl } { leaderboardState } =
 
 config : Analysis -> Leaderboard.Config ViewModelItem Msg
 config analysis =
-    { toId = .metaData >> .carNumber
+    { toId = .metadata >> .carNumber
     , toMsg = LeaderboardMsg
     , columns =
         [ intColumn { label = "", getter = .position }
-        , carNumberColumn_Wec 2025 { getter = .metaData }
-        , driverAndTeamColumn_Wec { getter = \item -> { metaData = item.metaData, currentDriver = item.currentDriver } }
+        , carNumberColumn_Wec 2025 { getter = .metadata }
+        , driverAndTeamColumn_Wec { getter = \item -> { metadata = item.metadata, currentDriver = item.currentDriver } }
         , intColumn { label = "Lap", getter = .lap }
         , sectorTimeColumn
             { label = "S1"
@@ -249,7 +249,7 @@ raceControlToLeaderboard { lapCount, cars } =
     let
         sortedItems =
             cars
-                |> NonEmpty.find (\car -> car.metaData.carNumber == "2")
+                |> NonEmpty.find (\car -> car.metadata.carNumber == "2")
                 |> Maybe.map
                     (\car ->
                         car.laps
@@ -259,7 +259,7 @@ raceControlToLeaderboard { lapCount, cars } =
                                     { position = index + 1
                                     , positionInClass = index + 1
                                     , status = car.status
-                                    , metaData = car.metaData
+                                    , metadata = car.metadata
                                     , lap = lap.lap
                                     , timing =
                                         { time = 0
@@ -285,6 +285,6 @@ raceControlToLeaderboard { lapCount, cars } =
     , items = sortedItems
     , itemsByClass =
         sortedItems
-            |> SortedList.gatherEqualsBy (.metaData >> .class)
-            |> List.map (\( first, rest ) -> ( first.metaData.class, Ordering.byPosition (first :: SortedList.toList rest) ))
+            |> SortedList.gatherEqualsBy (.metadata >> .class)
+            |> List.map (\( first, rest ) -> ( first.metadata.class, Ordering.byPosition (first :: SortedList.toList rest) ))
     }

--- a/app/app/Route/Debug.elm
+++ b/app/app/Route/Debug.elm
@@ -271,7 +271,7 @@ raceControlToLeaderboard { lapCount, cars } =
                                     , currentLap = Just lap
                                     , lastLap = Just lap
                                     , history = []
-                                    , currentDriver = Just (Driver lap.driver)
+                                    , currentDriver = Just lap.driver
                                     }
                                 )
                     )

--- a/app/app/Route/F1.elm
+++ b/app/app/Route/F1.elm
@@ -176,16 +176,16 @@ view app { analysis_F1, raceControl_F1 } { mode, leaderboardState } =
 
 config : Analysis -> Leaderboard.Config ViewModelItem Msg
 config analysis =
-    { toId = .metaData >> .carNumber
+    { toId = .metadata >> .carNumber
     , toMsg = LeaderboardMsg
     , columns =
         [ intColumn { label = "", getter = .position }
-        , stringColumn { label = "#", getter = .metaData >> .carNumber }
+        , stringColumn { label = "#", getter = .metadata >> .carNumber }
         , driverNameColumn_F1
             { label = "Driver"
             , getter = .currentDriver >> Maybe.map .name >> Maybe.withDefault ""
             }
-        , stringColumn { label = "Team", getter = .metaData >> .team }
+        , stringColumn { label = "Team", getter = .metadata >> .team }
         , intColumn { label = "Lap", getter = .lap }
         , customColumn
             { label = "Gap"

--- a/app/app/Route/F1.elm
+++ b/app/app/Route/F1.elm
@@ -183,7 +183,7 @@ config analysis =
         , stringColumn { label = "#", getter = .metaData >> .carNumber }
         , driverNameColumn_F1
             { label = "Driver"
-            , getter = .metaData >> .drivers >> Driver.findCurrentDriver >> Maybe.map .name >> Maybe.withDefault ""
+            , getter = .currentDriver >> Maybe.map .name >> Maybe.withDefault ""
             }
         , stringColumn { label = "Team", getter = .metaData >> .team }
         , intColumn { label = "Lap", getter = .lap }

--- a/app/app/Route/FormulaE/Season_/Event_.elm
+++ b/app/app/Route/FormulaE/Season_/Event_.elm
@@ -267,7 +267,7 @@ config season analysis =
     , columns =
         [ intColumn { label = "", getter = .position }
         , carNumberColumn_Wec season { getter = .metaData }
-        , driverAndTeamColumn_Wec { getter = .metaData }
+        , driverAndTeamColumn_Wec { getter = \item -> { metaData = item.metaData, currentDriver = item.currentDriver } }
         , intColumn { label = "Lap", getter = .lap }
         , customColumn
             { label = "Gap"

--- a/app/app/Route/FormulaE/Season_/Event_.elm
+++ b/app/app/Route/FormulaE/Season_/Event_.elm
@@ -262,12 +262,12 @@ statusBar { clock, lapTotal, lapCount, timeLimit } =
 
 config : Int -> Analysis -> Leaderboard.Config ViewModelItem Msg
 config season analysis =
-    { toId = .metaData >> .carNumber
+    { toId = .metadata >> .carNumber
     , toMsg = LeaderboardMsg
     , columns =
         [ intColumn { label = "", getter = .position }
-        , carNumberColumn_Wec season { getter = .metaData }
-        , driverAndTeamColumn_Wec { getter = \item -> { metaData = item.metaData, currentDriver = item.currentDriver } }
+        , carNumberColumn_Wec season { getter = .metadata }
+        , driverAndTeamColumn_Wec { getter = \item -> { metadata = item.metadata, currentDriver = item.currentDriver } }
         , intColumn { label = "Lap", getter = .lap }
         , customColumn
             { label = "Gap"

--- a/app/app/Route/Wec/Season_/Event_.elm
+++ b/app/app/Route/Wec/Season_/Event_.elm
@@ -372,12 +372,12 @@ analysisWidgets { clock } analysis viewModel =
 
 config : Int -> Analysis -> Leaderboard.Config ViewModelItem Msg
 config season analysis =
-    { toId = .metaData >> .carNumber
+    { toId = .metadata >> .carNumber
     , toMsg = LeaderboardMsg
     , columns =
         [ intColumn { label = "", getter = .position }
-        , carNumberColumn_Wec season { getter = .metaData }
-        , driverAndTeamColumn_Wec { getter = \item -> { metaData = item.metaData, currentDriver = item.currentDriver } }
+        , carNumberColumn_Wec season { getter = .metadata }
+        , driverAndTeamColumn_Wec { getter = \item -> { metadata = item.metadata, currentDriver = item.currentDriver } }
         , let
             view_ carNumber =
                 case Series.carImageUrl_Wec season carNumber of
@@ -389,8 +389,8 @@ config season analysis =
           in
           veryCustomColumn
             { label = "-"
-            , getter = .metaData >> .carNumber >> Lazy.lazy view_
-            , sorter = compareBy (.metaData >> .carNumber)
+            , getter = .metadata >> .carNumber >> Lazy.lazy view_
+            , sorter = compareBy (.metadata >> .carNumber)
             }
         , intColumn { label = "Lap", getter = .lap }
         , customColumn
@@ -487,12 +487,12 @@ eventTypeToString eventType =
 
 config_LeMans24h : Int -> Analysis -> Leaderboard.Config ViewModelItem Msg
 config_LeMans24h season analysis =
-    { toId = .metaData >> .carNumber
+    { toId = .metadata >> .carNumber
     , toMsg = LeaderboardMsg
     , columns =
         [ intColumn { label = "", getter = .position }
-        , carNumberColumn_Wec season { getter = .metaData }
-        , driverAndTeamColumn_Wec { getter = \item -> { metaData = item.metaData, currentDriver = item.currentDriver } }
+        , carNumberColumn_Wec season { getter = .metadata }
+        , driverAndTeamColumn_Wec { getter = \item -> { metadata = item.metadata, currentDriver = item.currentDriver } }
         , let
             view_ carNumber =
                 case Series.carImageUrl_Wec season carNumber of
@@ -504,8 +504,8 @@ config_LeMans24h season analysis =
           in
           veryCustomColumn
             { label = "-"
-            , getter = .metaData >> .carNumber >> Lazy.lazy view_
-            , sorter = compareBy (.metaData >> .carNumber)
+            , getter = .metadata >> .carNumber >> Lazy.lazy view_
+            , sorter = compareBy (.metadata >> .carNumber)
             }
         , intColumn { label = "Lap", getter = .lap }
         , customColumn

--- a/app/app/Route/Wec/Season_/Event_.elm
+++ b/app/app/Route/Wec/Season_/Event_.elm
@@ -377,7 +377,7 @@ config season analysis =
     , columns =
         [ intColumn { label = "", getter = .position }
         , carNumberColumn_Wec season { getter = .metaData }
-        , driverAndTeamColumn_Wec { getter = .metaData }
+        , driverAndTeamColumn_Wec { getter = \item -> { metaData = item.metaData, currentDriver = item.currentDriver } }
         , let
             view_ carNumber =
                 case Series.carImageUrl_Wec season carNumber of
@@ -492,7 +492,7 @@ config_LeMans24h season analysis =
     , columns =
         [ intColumn { label = "", getter = .position }
         , carNumberColumn_Wec season { getter = .metaData }
-        , driverAndTeamColumn_Wec { getter = .metaData }
+        , driverAndTeamColumn_Wec { getter = \item -> { metaData = item.metaData, currentDriver = item.currentDriver } }
         , let
             view_ carNumber =
                 case Series.carImageUrl_Wec season carNumber of

--- a/app/src/Data/F1/Decoder.elm
+++ b/app/src/Data/F1/Decoder.elm
@@ -1,6 +1,7 @@
-module Data.F1.Decoder exposing (Car, Data, Driver, Lap, decoder)
+module Data.F1.Decoder exposing (Car, Data, Lap, decoder)
 
 import Json.Decode as Decode exposing (Decoder, field, int, string)
+import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration, durationDecoder)
 
 
@@ -17,10 +18,6 @@ type alias Car =
     , driver : Driver
     , laps : List Lap
     }
-
-
-type alias Driver =
-    { name : String }
 
 
 type alias Lap =

--- a/app/src/Data/F1/Preprocess.elm
+++ b/app/src/Data/F1/Preprocess.elm
@@ -6,7 +6,7 @@ import Data.F1.Decoder as F1
 import List.Extra as List
 import Motorsport.Car exposing (Car, Status(..))
 import Motorsport.Class as Class
-import Motorsport.Lap as Lap
+import Motorsport.Driver exposing (Driver)
 import Motorsport.Lap.Performance exposing (findPersonalBest)
 import Motorsport.Manufacturer as Manufacturer
 
@@ -78,7 +78,7 @@ getPositionAt { carNumber, lapNumber } ordersByLap =
 
 preprocess_ :
     { carNumber : String
-    , driver : F1.Driver
+    , driver : Driver
     , laps : List F1.Lap
     , startPositions : List String
     , ordersByLap : OrdersByLap

--- a/app/src/Data/F1/Preprocess.elm
+++ b/app/src/Data/F1/Preprocess.elm
@@ -86,7 +86,7 @@ preprocess_ :
     -> Car
 preprocess_ { carNumber, driver, laps, startPositions, ordersByLap } =
     let
-        metaData =
+        metadata =
             { carNumber = carNumber
             , drivers = [ driver ]
             , class = Class.none
@@ -130,7 +130,7 @@ preprocess_ { carNumber, driver, laps, startPositions, ordersByLap } =
                         }
                     )
     in
-    { metaData = metaData
+    { metadata = metadata
     , startPosition = startPosition
     , laps = laps_
     , currentLap = Nothing

--- a/app/src/Data/F1/Preprocess.elm
+++ b/app/src/Data/F1/Preprocess.elm
@@ -105,7 +105,7 @@ preprocess_ { carNumber, driver, laps, startPositions, ordersByLap } =
                 |> List.indexedMap
                     (\count { lap, time } ->
                         { carNumber = carNumber
-                        , driver = driver.name
+                        , driver = driver
                         , lap = lap
                         , position =
                             getPositionAt { carNumber = carNumber, lapNumber = lap } ordersByLap

--- a/app/src/Data/F1/Preprocess.elm
+++ b/app/src/Data/F1/Preprocess.elm
@@ -88,7 +88,7 @@ preprocess_ { carNumber, driver, laps, startPositions, ordersByLap } =
     let
         metaData =
             { carNumber = carNumber
-            , drivers = [ { name = driver.name, isCurrentDriver = True } ]
+            , drivers = [ driver ]
             , class = Class.none
             , group = "TODO"
             , team = driverToTeamName_2022 driver.name
@@ -136,6 +136,7 @@ preprocess_ { carNumber, driver, laps, startPositions, ordersByLap } =
     , currentLap = Nothing
     , lastLap = Nothing
     , status = PreRace
+    , currentDriver = Just driver
     }
 
 

--- a/app/src/Data/FormulaE.elm
+++ b/app/src/Data/FormulaE.elm
@@ -119,13 +119,15 @@ classDecoder =
 
 carDecoder : Decoder Car
 carDecoder =
-    Decode.map6 Car
+    Decode.map7 Car
         metaDataDecoder
         (field "startPosition" int)
         (field "laps" (Decode.list lapDecoder_))
         (field "currentLap" (Decode.maybe lapDecoder_))
         (field "lastLap" (Decode.maybe lapDecoder_))
         (Decode.succeed PreRace)
+        (Decode.succeed Nothing)
+
 
 
 metaDataDecoder : Decoder Car.MetaData
@@ -141,9 +143,8 @@ metaDataDecoder =
 
 driverDecoder : Decoder Driver
 driverDecoder =
-    Decode.map2 Driver
+    Decode.map Driver
         (field "name" string)
-        (field "isCurrentDriver" bool)
 
 
 lapDecoder_ : Decoder Motorsport.Lap.Lap

--- a/app/src/Data/FormulaE.elm
+++ b/app/src/Data/FormulaE.elm
@@ -120,7 +120,7 @@ classDecoder =
 carDecoder : Decoder Car
 carDecoder =
     Decode.map7 Car
-        metaDataDecoder
+        metadataDecoder
         (field "startPosition" int)
         (field "laps" (Decode.list lapDecoder_))
         (field "currentLap" (Decode.maybe lapDecoder_))
@@ -129,10 +129,9 @@ carDecoder =
         (Decode.succeed Nothing)
 
 
-
-metaDataDecoder : Decoder Car.MetaData
-metaDataDecoder =
-    Decode.succeed Car.MetaData
+metadataDecoder : Decoder Car.Metadata
+metadataDecoder =
+    Decode.succeed Car.Metadata
         |> required "carNumber" string
         |> required "drivers" (Decode.list driverDecoder)
         |> required "class" classDecoder

--- a/app/src/Data/FormulaE.elm
+++ b/app/src/Data/FormulaE.elm
@@ -150,7 +150,7 @@ lapDecoder_ : Decoder Motorsport.Lap.Lap
 lapDecoder_ =
     Decode.succeed Motorsport.Lap.Lap
         |> required "carNumber" string
-        |> required "driver" string
+        |> required "driver" (Decode.map Driver string)
         |> required "lap" int
         |> required "position" (Decode.maybe int)
         |> required "time" durationDecoder

--- a/app/src/Data/Wec.elm
+++ b/app/src/Data/Wec.elm
@@ -166,7 +166,7 @@ miniSectorDecoder =
 carDecoder : Decoder Car
 carDecoder =
     Decode.map7 Car
-        metaDataDecoder
+        metadataDecoder
         (field "startPosition" int)
         (field "laps" (Decode.list lapDecoder_))
         (field "currentLap" (Decode.maybe lapDecoder_))
@@ -175,9 +175,9 @@ carDecoder =
         (Decode.succeed Nothing)
 
 
-metaDataDecoder : Decoder Car.MetaData
-metaDataDecoder =
-    Decode.succeed Car.MetaData
+metadataDecoder : Decoder Car.Metadata
+metadataDecoder =
+    Decode.succeed Car.Metadata
         |> required "carNumber" string
         |> required "drivers" (Decode.list driverDecoder)
         |> required "class" classDecoder

--- a/app/src/Data/Wec.elm
+++ b/app/src/Data/Wec.elm
@@ -10,7 +10,7 @@ module Data.Wec exposing
 
 -}
 
-import Json.Decode as Decode exposing (Decoder, bool, field, float, int, list, string)
+import Json.Decode as Decode exposing (Decoder, field, float, int, list, string)
 import Json.Decode.Extra
 import Json.Decode.Pipeline exposing (optional, required)
 import Motorsport.Car as Car exposing (Car, Status(..))
@@ -165,13 +165,14 @@ miniSectorDecoder =
 
 carDecoder : Decoder Car
 carDecoder =
-    Decode.map6 Car
+    Decode.map7 Car
         metaDataDecoder
         (field "startPosition" int)
         (field "laps" (Decode.list lapDecoder_))
         (field "currentLap" (Decode.maybe lapDecoder_))
         (field "lastLap" (Decode.maybe lapDecoder_))
         (Decode.succeed PreRace)
+        (Decode.succeed Nothing)
 
 
 metaDataDecoder : Decoder Car.MetaData
@@ -187,9 +188,8 @@ metaDataDecoder =
 
 driverDecoder : Decoder Driver
 driverDecoder =
-    Decode.map2 Driver
+    Decode.map Driver
         (field "name" string)
-        (field "isCurrentDriver" bool)
 
 
 lapDecoder_ : Decoder Motorsport.Lap.Lap

--- a/app/src/Data/Wec.elm
+++ b/app/src/Data/Wec.elm
@@ -196,7 +196,7 @@ lapDecoder_ : Decoder Motorsport.Lap.Lap
 lapDecoder_ =
     Decode.succeed Motorsport.Lap.Lap
         |> required "carNumber" string
-        |> required "driver" string
+        |> required "driver" (Decode.map Driver string)
         |> required "lap" int
         |> required "position" (Decode.maybe int)
         |> required "time" durationDecoder

--- a/package/src/Motorsport/Car.elm
+++ b/package/src/Motorsport/Car.elm
@@ -1,12 +1,12 @@
 module Motorsport.Car exposing
-    ( Car, MetaData, CarNumber
+    ( Car, Metadata, CarNumber
     , Status(..), hasRetired, statusToString
     , setStatus
     )
 
 {-|
 
-@docs Car, MetaData, CarNumber
+@docs Car, Metadata, CarNumber
 @docs Status, hasRetired, statusToString
 @docs setStatus
 
@@ -19,7 +19,7 @@ import Motorsport.Manufacturer exposing (Manufacturer)
 
 
 type alias Car =
-    { metaData : MetaData
+    { metadata : Metadata
     , startPosition : Int
     , laps : List Lap
     , currentLap : Maybe Lap
@@ -29,7 +29,7 @@ type alias Car =
     }
 
 
-type alias MetaData =
+type alias Metadata =
     { carNumber : CarNumber
     , drivers : List Driver
     , class : Class

--- a/package/src/Motorsport/Car.elm
+++ b/package/src/Motorsport/Car.elm
@@ -25,6 +25,7 @@ type alias Car =
     , currentLap : Maybe Lap
     , lastLap : Maybe Lap
     , status : Status
+    , currentDriver : Maybe Driver
     }
 
 

--- a/package/src/Motorsport/Chart/LapTimeChartsByDriver.elm
+++ b/package/src/Motorsport/Chart/LapTimeChartsByDriver.elm
@@ -94,7 +94,7 @@ view analysis { lapTotal, cars } =
             |> List.map
                 (\car ->
                     li [ css [ listStyle none ] ]
-                        [ p [] [ text car.metaData.carNumber ]
+                        [ p [] [ text car.metadata.carNumber ]
                         , svg [ viewBox 0 0 w h ]
                             [ xAxis lapTotal
                             , yAxis fastestLapTime

--- a/package/src/Motorsport/Chart/PositionHistory.elm
+++ b/package/src/Motorsport/Chart/PositionHistory.elm
@@ -107,7 +107,7 @@ view { clock, lapTotal, cars } =
                     (\car ->
                         let
                             { carNumber, team, class } =
-                                car.metaData
+                                car.metadata
 
                             positions =
                                 car.laps
@@ -149,7 +149,7 @@ history { x, y, svgPalette, label } ( car, positions ) =
         , positionLabels =
             (car.startPosition :: positions)
                 |> List.indexedMap (\i position -> ( x i, y position ))
-                |> positionLabels { label = text car.metaData.carNumber }
+                |> positionLabels { label = text car.metadata.carNumber }
         }
 
 

--- a/package/src/Motorsport/Chart/Tracker.elm
+++ b/package/src/Motorsport/Chart/Tracker.elm
@@ -160,7 +160,7 @@ renderCars config viewModel =
             |> List.reverse
             |> List.map
                 (\car ->
-                    ( car.metaData.carNumber
+                    ( car.metadata.carNumber
                     , Lazy.lazy2 renderCarOnTrack config car
                     )
                 )
@@ -194,7 +194,7 @@ renderCar : ViewModelItem -> { x : Float, y : Float } -> Svg msg
 renderCar car { x, y } =
     let
         { carNumber, class } =
-            car.metaData
+            car.metadata
     in
     g [ Attributes.transform [ Translate x y ] ]
         [ Lazy.lazy2 carWithPositionInClass car.positionInClass { carNumber = carNumber, class = class } ]

--- a/package/src/Motorsport/Driver.elm
+++ b/package/src/Motorsport/Driver.elm
@@ -1,14 +1,5 @@
-module Motorsport.Driver exposing (Driver, findCurrentDriver)
+module Motorsport.Driver exposing (Driver)
 
 
 type alias Driver =
-    { name : String
-    , isCurrentDriver : Bool
-    }
-
-
-findCurrentDriver : List Driver -> Maybe Driver
-findCurrentDriver drivers =
-    drivers
-        |> List.filter .isCurrentDriver
-        |> List.head
+    { name : String }

--- a/package/src/Motorsport/Lap.elm
+++ b/package/src/Motorsport/Lap.elm
@@ -19,12 +19,13 @@ module Motorsport.Lap exposing
 -}
 
 import List.Extra
+import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
 
 
 type alias Lap =
     { carNumber : String
-    , driver : String
+    , driver : Driver
     , lap : Int
     , position : Maybe Int
     , time : Duration
@@ -69,7 +70,7 @@ type alias MiniSectorData =
 empty : Lap
 empty =
     { carNumber = ""
-    , driver = ""
+    , driver = Driver ""
     , lap = 0
     , position = Nothing
     , time = 0

--- a/package/src/Motorsport/Leaderboard.elm
+++ b/package/src/Motorsport/Leaderboard.elm
@@ -269,12 +269,12 @@ driverNameColumn_F1 { label, getter } =
     }
 
 
-driverAndTeamColumn_Wec : { getter : data -> { a | metaData : { b | drivers : List Driver, team : String }, currentDriver : Maybe Driver } } -> Column data msg
+driverAndTeamColumn_Wec : { getter : data -> { a | metadata : { b | drivers : List Driver, team : String }, currentDriver : Maybe Driver } } -> Column data msg
 driverAndTeamColumn_Wec { getter } =
     let
-        view_ { metaData, currentDriver } =
+        view_ { metadata, currentDriver } =
             div [ css [ displayFlex, flexDirection column, property "row-gap" "5px" ] ]
-                [ div [] [ text metaData.team ]
+                [ div [] [ text metadata.team ]
                 , div [ css [ displayFlex, property "column-gap" "10px" ] ] <|
                     List.map
                         (\driver ->
@@ -292,7 +292,7 @@ driverAndTeamColumn_Wec { getter } =
                                 ]
                                 [ text (formatName driver.name) ]
                         )
-                        metaData.drivers
+                        metadata.drivers
                 ]
 
         formatName name =
@@ -302,9 +302,9 @@ driverAndTeamColumn_Wec { getter } =
                 |> Maybe.withDefault (String.toUpper name)
     in
     { name = "Team / Driver"
-    , view = getter >> (\{ metaData, currentDriver } -> Lazy.lazy view_ { metaData = metaData, currentDriver = currentDriver })
-    , sorter = compareBy (getter >> .metaData >> .team)
-    , filter = \data query -> getter data |> (.metaData >> .team) |> String.startsWith query
+    , view = getter >> (\{ metadata, currentDriver } -> Lazy.lazy view_ { metadata = metadata, currentDriver = currentDriver })
+    , sorter = compareBy (getter >> .metadata >> .team)
+    , filter = \data query -> getter data |> (.metadata >> .team) |> String.startsWith query
     }
 
 

--- a/package/src/Motorsport/Leaderboard.elm
+++ b/package/src/Motorsport/Leaderboard.elm
@@ -279,14 +279,14 @@ driverAndTeamColumn_Wec { getter } =
                     List.map
                         (\driver ->
                             let
-                                isNotCurrentDriver =
-                                    Maybe.map .name currentDriver /= Just driver.name
+                                isCurrentDriver =
+                                    Maybe.map .name currentDriver == Just driver.name
                             in
                             div
                                 [ css
                                     [ fontSize (px 10)
                                     , fontStyle italic
-                                    , when isNotCurrentDriver
+                                    , when (not isCurrentDriver)
                                         (color (hsl 0 0 0.75))
                                     ]
                                 ]

--- a/package/src/Motorsport/RaceControl.elm
+++ b/package/src/Motorsport/RaceControl.elm
@@ -360,8 +360,13 @@ applyEventToCar : Event -> Car -> Car
 applyEventToCar event car =
     case event.eventType of
         RaceStart ->
+            let
+                currentLap =
+                    List.head car.laps
+            in
             { car
-                | currentLap = List.head car.laps
+                | currentLap = currentLap
+                , currentDriver = currentLap |> Maybe.map (.driver >> Driver)
                 , status = Racing
             }
 
@@ -372,9 +377,14 @@ applyEventToCar event car =
             Car.setStatus Car.Checkered car
 
         CarEvent _ (LapCompleted lapNumber) ->
+            let
+                currentLap =
+                    List.Extra.find (\lap -> lap.lap == lapNumber + 1) car.laps
+            in
             { car
-                | currentLap = List.Extra.find (\lap -> lap.lap == lapNumber + 1) car.laps
+                | currentLap = currentLap
                 , lastLap = List.Extra.find (\lap -> lap.lap == lapNumber) car.laps
+                , currentDriver = currentLap |> Maybe.map (.driver >> Driver)
             }
 
 

--- a/package/src/Motorsport/RaceControl.elm
+++ b/package/src/Motorsport/RaceControl.elm
@@ -5,7 +5,6 @@ import List.NonEmpty as NonEmpty exposing (NonEmpty)
 import Motorsport.Car as Car exposing (Car, CarNumber, Status(..))
 import Motorsport.Class as Class
 import Motorsport.Clock as Clock exposing (Model(..))
-import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Lap as Lap
 import Motorsport.Manufacturer as Manufacturer
@@ -297,7 +296,7 @@ updateCars raceClock cars =
                 { car
                     | currentLap = currentLap
                     , lastLap = Lap.findLastLapAt raceClock car.laps
-                    , currentDriver = currentLap |> Maybe.map (\lap -> Driver lap.driver)
+                    , currentDriver = currentLap |> Maybe.map .driver
                 }
             )
         |> NonEmpty.sortWith
@@ -366,7 +365,7 @@ applyEventToCar event car =
             in
             { car
                 | currentLap = currentLap
-                , currentDriver = currentLap |> Maybe.map (.driver >> Driver)
+                , currentDriver = currentLap |> Maybe.map .driver
                 , status = Racing
             }
 
@@ -384,7 +383,7 @@ applyEventToCar event car =
             { car
                 | currentLap = currentLap
                 , lastLap = List.Extra.find (\lap -> lap.lap == lapNumber) car.laps
-                , currentDriver = currentLap |> Maybe.map (.driver >> Driver)
+                , currentDriver = currentLap |> Maybe.map .driver
             }
 
 

--- a/package/src/Motorsport/RaceControl.elm
+++ b/package/src/Motorsport/RaceControl.elm
@@ -5,6 +5,7 @@ import List.NonEmpty as NonEmpty exposing (NonEmpty)
 import Motorsport.Car as Car exposing (Car, CarNumber, Status(..))
 import Motorsport.Class as Class
 import Motorsport.Clock as Clock exposing (Model(..))
+import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Lap as Lap
 import Motorsport.Manufacturer as Manufacturer
@@ -50,6 +51,7 @@ placeholder =
             , currentLap = Nothing
             , lastLap = Nothing
             , status = PreRace
+            , currentDriver = Nothing
             }
     in
     init (NonEmpty.singleton dummyCar)
@@ -288,9 +290,14 @@ updateCars raceClock cars =
     cars
         |> NonEmpty.map
             (\car ->
+                let
+                    currentLap =
+                        Lap.findCurrentLap raceClock car.laps
+                in
                 { car
-                    | currentLap = Lap.findCurrentLap raceClock car.laps
+                    | currentLap = currentLap
                     , lastLap = Lap.findLastLapAt raceClock car.laps
+                    , currentDriver = currentLap |> Maybe.map (\lap -> Driver lap.driver)
                 }
             )
         |> NonEmpty.sortWith

--- a/package/src/Motorsport/RaceControl.elm
+++ b/package/src/Motorsport/RaceControl.elm
@@ -45,7 +45,7 @@ placeholder : Model
 placeholder =
     let
         dummyCar =
-            { metaData = { carNumber = "", drivers = [], class = Class.none, group = "", team = "", manufacturer = Manufacturer.Other }
+            { metadata = { carNumber = "", drivers = [], class = Class.none, group = "", team = "", manufacturer = Manufacturer.Other }
             , startPosition = 0
             , laps = []
             , currentLap = Nothing
@@ -113,7 +113,7 @@ calcEvents timeLimit cars =
                             |> List.map
                                 (\lap ->
                                     { eventTime = lap.elapsed
-                                    , eventType = CarEvent car.metaData.carNumber (LapCompleted lap.lap)
+                                    , eventType = CarEvent car.metadata.carNumber (LapCompleted lap.lap)
                                     }
                                 )
                     )
@@ -128,10 +128,10 @@ calcEvents timeLimit cars =
                                 (\finalLap ->
                                     -- 時間制限より前に終わった車両はリタイア、以降はチェッカー
                                     if finalLap.elapsed < timeLimit then
-                                        { eventTime = finalLap.elapsed, eventType = CarEvent car.metaData.carNumber Retirement }
+                                        { eventTime = finalLap.elapsed, eventType = CarEvent car.metadata.carNumber Retirement }
 
                                     else
-                                        { eventTime = finalLap.elapsed, eventType = CarEvent car.metaData.carNumber Checkered }
+                                        { eventTime = finalLap.elapsed, eventType = CarEvent car.metadata.carNumber Checkered }
                                 )
                     )
     in
@@ -340,7 +340,7 @@ applyEvents currentElapsed events cars =
                                 (\event ->
                                     case event.eventType of
                                         CarEvent carNumber _ ->
-                                            carNumber == car.metaData.carNumber
+                                            carNumber == car.metadata.carNumber
 
                                         _ ->
                                             False

--- a/package/src/Motorsport/RaceControl/ViewModel.elm
+++ b/package/src/Motorsport/RaceControl/ViewModel.elm
@@ -23,6 +23,7 @@ import List.NonEmpty as NonEmpty exposing (NonEmpty)
 import Motorsport.Car as Car exposing (Car, Status)
 import Motorsport.Class exposing (Class)
 import Motorsport.Clock as Clock
+import Motorsport.Driver exposing (Driver)
 import Motorsport.Duration exposing (Duration)
 import Motorsport.Gap as Gap exposing (Gap)
 import Motorsport.Lap as Lap exposing (Lap, MiniSector(..), Sector(..), completedLapsAt)
@@ -48,6 +49,7 @@ type alias ViewModelItem =
     , currentLap : Maybe Lap
     , lastLap : Maybe Lap
     , history : List Lap
+    , currentDriver : Maybe Driver
     }
 
 
@@ -88,23 +90,7 @@ init { clock, lapCount, cars } =
                         { position = index + 1
                         , positionInClass = positionInClass
                         , status = car.status
-                        , metaData =
-                            { metaData
-                                | drivers =
-                                    List.map
-                                        (\{ name } ->
-                                            { name = name
-                                            , isCurrentDriver =
-                                                case car.currentLap of
-                                                    Just currentLap ->
-                                                        name == currentLap.driver
-
-                                                    Nothing ->
-                                                        False
-                                            }
-                                        )
-                                        car.metaData.drivers
-                            }
+                        , metaData = metaData
                         , lap = lastLap.lap
                         , timing =
                             init_timing clock
@@ -115,6 +101,7 @@ init { clock, lapCount, cars } =
                         , currentLap = car.currentLap
                         , lastLap = car.lastLap
                         , history = completedLapsAt raceClock car.laps
+                        , currentDriver = car.currentDriver
                         }
                     )
 

--- a/package/src/Motorsport/RaceControl/ViewModel.elm
+++ b/package/src/Motorsport/RaceControl/ViewModel.elm
@@ -43,7 +43,7 @@ type alias ViewModelItem =
     { position : Int
     , positionInClass : Int
     , status : Status
-    , metaData : Car.MetaData
+    , metadata : Car.Metadata
     , lap : Int
     , timing : Timing
     , currentLap : Maybe Lap
@@ -77,11 +77,11 @@ init { clock, lapCount, cars } =
                             raceClock =
                                 { elapsed = Clock.getElapsed clock }
 
-                            metaData =
-                                car.metaData
+                            metadata =
+                                car.metadata
 
                             positionInClass =
-                                Dict.get car.metaData.carNumber positionsInClass
+                                Dict.get car.metadata.carNumber positionsInClass
                                     |> Maybe.withDefault 1
 
                             lastLap =
@@ -90,7 +90,7 @@ init { clock, lapCount, cars } =
                         { position = index + 1
                         , positionInClass = positionInClass
                         , status = car.status
-                        , metaData = metaData
+                        , metadata = metadata
                         , lap = lastLap.lap
                         , timing =
                             init_timing clock
@@ -112,8 +112,8 @@ init { clock, lapCount, cars } =
     , items = sortedItems
     , itemsByClass =
         sortedItems
-            |> SortedList.gatherEqualsBy (.metaData >> .class)
-            |> List.map (\( first, rest ) -> ( first.metaData.class, Ordering.byPosition (first :: SortedList.toList rest) ))
+            |> SortedList.gatherEqualsBy (.metadata >> .class)
+            |> List.map (\( first, rest ) -> ( first.metadata.class, Ordering.byPosition (first :: SortedList.toList rest) ))
     }
 
 
@@ -159,11 +159,11 @@ positionsInClassByCarNumber : NonEmpty Car -> Dict String Int
 positionsInClassByCarNumber cars =
     cars
         |> NonEmpty.toList
-        |> List.Extra.gatherEqualsBy (.metaData >> .class)
+        |> List.Extra.gatherEqualsBy (.metadata >> .class)
         |> List.concatMap
             (\( firstCar, restCars ) ->
                 (firstCar :: restCars)
-                    |> List.indexedMap (\index car -> ( car.metaData.carNumber, index + 1 ))
+                    |> List.indexedMap (\index car -> ( car.metadata.carNumber, index + 1 ))
             )
         |> Dict.fromList
 

--- a/package/src/Motorsport/Widget/BestLapTimes.elm
+++ b/package/src/Motorsport/Widget/BestLapTimes.elm
@@ -55,8 +55,8 @@ processClassBestTimes viewModel =
                                 car.lastLap
                                     |> Maybe.map
                                         (\lap ->
-                                            { class = car.metaData.class
-                                            , carNumber = car.metaData.carNumber
+                                            { class = car.metadata.class
+                                            , carNumber = car.metadata.carNumber
                                             , bestTime = lap.best
                                             , sector1 = lap.sector_1
                                             , sector2 = lap.sector_2

--- a/package/src/Motorsport/Widget/CloseBattles.elm
+++ b/package/src/Motorsport/Widget/CloseBattles.elm
@@ -129,7 +129,7 @@ battleHeaderView cars =
         carNumbers =
             cars
                 |> NonEmpty.toList
-                |> List.map (.metaData >> .carNumber)
+                |> List.map (.metadata >> .carNumber)
                 |> String.join " - "
     in
     div
@@ -231,7 +231,7 @@ carTimeRow car carLaps allCarsLaps =
                 ]
     in
     Html.tr [ css [ children [ Css.Global.td [ Css.padding Css.zero ] ] ] ]
-        (Html.th [ css [ Css.width (px 25) ] ] [ text car.metaData.carNumber ]
+        (Html.th [ css [ Css.width (px 25) ] ] [ text car.metadata.carNumber ]
             :: intervalCell
             :: lapCells
         )
@@ -285,9 +285,9 @@ battleChart cars =
             cars
                 |> NonEmpty.map
                     (\car ->
-                        { carNumber = car.metaData.carNumber
+                        { carNumber = car.metadata.carNumber
                         , laps = ViewModel.getRecentLaps 10 options car.history
-                        , color = Manufacturer.toColorWithFallback car.metaData
+                        , color = Manufacturer.toColorWithFallback car.metadata
                         }
                     )
 

--- a/package/src/Motorsport/Widget/LapTimeProgression.elm
+++ b/package/src/Motorsport/Widget/LapTimeProgression.elm
@@ -94,9 +94,9 @@ processClassProgressionData clock viewModel =
                                         allLaps =
                                             extractLapDataForCar clock car.history
                                     in
-                                    { carNumber = car.metaData.carNumber
+                                    { carNumber = car.metadata.carNumber
                                     , laps = allLaps
-                                    , color = Manufacturer.toColorWithFallback car.metaData
+                                    , color = Manufacturer.toColorWithFallback car.metadata
                                     }
                                 )
                             |> List.filter (\car -> List.length car.laps >= 2)

--- a/package/src/Motorsport/Widget/PositionProgression.elm
+++ b/package/src/Motorsport/Widget/PositionProgression.elm
@@ -113,9 +113,9 @@ processClassPositionData clock viewModel =
                                         positionHistory =
                                             extractPositionDataForCar lapThreshold car.history
                                     in
-                                    { carNumber = car.metaData.carNumber
+                                    { carNumber = car.metadata.carNumber
                                     , positions = positionHistory
-                                    , color = Manufacturer.toColorWithFallback car.metaData
+                                    , color = Manufacturer.toColorWithFallback car.metadata
                                     }
                                 )
                             |> List.filter (\car -> List.length car.positions >= 2)

--- a/package/tests/Motorsport/RaceControl/ViewModelTest.elm
+++ b/package/tests/Motorsport/RaceControl/ViewModelTest.elm
@@ -134,9 +134,7 @@ createMetaData carNumber =
 
 createDriver : String -> Driver
 createDriver name =
-    { name = name
-    , isCurrentDriver = True
-    }
+    { name = name }
 
 
 createTiming : Gap -> Timing

--- a/package/tests/Motorsport/RaceControl/ViewModelTest.elm
+++ b/package/tests/Motorsport/RaceControl/ViewModelTest.elm
@@ -127,14 +127,9 @@ createMetadata carNumber =
     , class = Class.none
     , group = "Test Group"
     , team = "Test Team"
-    , drivers = [ createDriver "Test Driver" ]
+    , drivers = [ Driver "Test Driver" ]
     , manufacturer = Manufacturer.Other
     }
-
-
-createDriver : String -> Driver
-createDriver name =
-    { name = name }
 
 
 createTiming : Gap -> Timing

--- a/package/tests/Motorsport/RaceControl/ViewModelTest.elm
+++ b/package/tests/Motorsport/RaceControl/ViewModelTest.elm
@@ -34,8 +34,8 @@ suite =
                             , items = sortedItems
                             , itemsByClass =
                                 sortedItems
-                                    |> SortedList.gatherEqualsBy (.metaData >> .class)
-                                    |> List.map (\( first, rest ) -> ( first.metaData.class, Ordering.byPosition (first :: SortedList.toList rest) ))
+                                    |> SortedList.gatherEqualsBy (.metadata >> .class)
+                                    |> List.map (\( first, rest ) -> ( first.metadata.class, Ordering.byPosition (first :: SortedList.toList rest) ))
                             }
                     in
                     ViewModel.groupCarsByCloseIntervals viewModel
@@ -61,8 +61,8 @@ suite =
                             , items = sortedItems
                             , itemsByClass =
                                 sortedItems
-                                    |> SortedList.gatherEqualsBy (.metaData >> .class)
-                                    |> List.map (\( first, rest ) -> ( first.metaData.class, Ordering.byPosition (first :: SortedList.toList rest) ))
+                                    |> SortedList.gatherEqualsBy (.metadata >> .class)
+                                    |> List.map (\( first, rest ) -> ( first.metadata.class, Ordering.byPosition (first :: SortedList.toList rest) ))
                             }
                     in
                     ViewModel.groupCarsByCloseIntervals viewModel
@@ -88,8 +88,8 @@ suite =
                             , items = sortedItems
                             , itemsByClass =
                                 sortedItems
-                                    |> SortedList.gatherEqualsBy (.metaData >> .class)
-                                    |> List.map (\( first, rest ) -> ( first.metaData.class, Ordering.byPosition (first :: SortedList.toList rest) ))
+                                    |> SortedList.gatherEqualsBy (.metadata >> .class)
+                                    |> List.map (\( first, rest ) -> ( first.metadata.class, Ordering.byPosition (first :: SortedList.toList rest) ))
                             }
                     in
                     ViewModel.groupCarsByCloseIntervals viewModel
@@ -112,7 +112,7 @@ createViewModelItemWithGap position carNumber gap =
     { position = position
     , positionInClass = 1
     , status = Racing
-    , metaData = createMetaData carNumber
+    , metadata = createMetadata carNumber
     , lap = 5
     , timing = createTiming gap
     , currentLap = Nothing
@@ -121,8 +121,8 @@ createViewModelItemWithGap position carNumber gap =
     }
 
 
-createMetaData : String -> Car.MetaData
-createMetaData carNumber =
+createMetadata : String -> Car.Metadata
+createMetadata carNumber =
     { carNumber = carNumber
     , class = Class.none
     , group = "Test Group"


### PR DESCRIPTION
This pull request introduces a refactor across multiple files to rename the `MetaData` type and related fields to `Metadata`, and to add support for tracking the current driver in car data structures. These changes improve consistency and enhance functionality by allowing the system to handle driver-specific data more effectively. The most important changes are grouped below by theme:

### Refactor: Rename `MetaData` to `Metadata`
* Renamed the `MetaData` type to `Metadata` and updated all references in `Motorsport/Car.elm` and related files. This includes changes to the `Car` type alias and all associated fields (`metaData` → `metadata`). [[1]](diffhunk://#diff-dc0ad649c68f58e79913f84de02d2667eb6fdc283c2517f318cbf8a9bc3b07f8L2-R9) [[2]](diffhunk://#diff-dc0ad649c68f58e79913f84de02d2667eb6fdc283c2517f318cbf8a9bc3b07f8L22-R32)
* Updated all usage of `.metaData` to `.metadata` in leaderboard configurations, car processing, and chart rendering across various modules, such as `Route/Debug.elm`, `Route/F1.elm`, and `Chart/LapTimeChartsByDriver.elm`. [[1]](diffhunk://#diff-a959ef857f0c58013cc8364303c325c8082b34654bd717692755348393de4639L175-R181) [[2]](diffhunk://#diff-6741cf107068900a5e137cb5fcca816b94ff0cfda1e3e37e7040bf5bc0dd3ca9L179-R188) [[3]](diffhunk://#diff-0879d2845238a3e0e6e52eb11dd32c0d2924f0311c24c558badcc98fbe66fd69L97-R97)

### Feature: Add `currentDriver` to `Car` type
* Introduced a `currentDriver` field to the `Car` type in `Motorsport/Car.elm` to track the currently active driver. Updated all relevant decoders and constructors to include this field. [[1]](diffhunk://#diff-dc0ad649c68f58e79913f84de02d2667eb6fdc283c2517f318cbf8a9bc3b07f8L22-R32) [[2]](diffhunk://#diff-ef3096e47cc16a969322e09d9f8aa6a12df864a7b73a0dacec39824e5abb3524L122-R134) [[3]](diffhunk://#diff-e4c88a6aa3ee2468d56e1ce8e6727d1620bd288f5131c92875c453dd947a93deL133-R139)
* Modified leaderboard columns and data processing logic to utilize the `currentDriver` field for displaying driver-specific information, such as names and teams. [[1]](diffhunk://#diff-a959ef857f0c58013cc8364303c325c8082b34654bd717692755348393de4639L175-R181) [[2]](diffhunk://#diff-0854c1c6c01df1d2f3ef0fae3a7bba4baee7a15f353396960e2f231d22cfd26aL265-R270)

### Decoder Updates
* Adjusted decoders in `Data/F1/Decoder.elm`, `Data/FormulaE.elm`, and `Data/Wec.elm` to accommodate the `currentDriver` field and the `Metadata` renaming. This includes changes to `metadataDecoder` and driver decoding logic. [[1]](diffhunk://#diff-10a8748385eb502719df1cf86a8f0a09c9be6691b1c2072178e12fc7f0b7ae5cL1-R4) [[2]](diffhunk://#diff-ef3096e47cc16a969322e09d9f8aa6a12df864a7b73a0dacec39824e5abb3524L144-R153) [[3]](diffhunk://#diff-b535a5ebbb04544c152fe029d0e47933874b730fef2e9d8b85dfe68c92ce209dL168-R180)

### Miscellaneous Updates
* Removed the `Driver` type alias from `Data/F1/Decoder.elm` and replaced it with the `Driver` type from `Motorsport.Driver`. Updated imports and references accordingly. [[1]](diffhunk://#diff-10a8748385eb502719df1cf86a8f0a09c9be6691b1c2072178e12fc7f0b7ae5cL22-L25) [[2]](diffhunk://#diff-e4c88a6aa3ee2468d56e1ce8e6727d1620bd288f5131c92875c453dd947a93deL9-R9)

These changes ensure a more consistent and extensible data model, particularly for handling driver-related information in motorsport applications.