### PR TITLE
feat: LiveStandings wiget

### DIFF
--- a/app/app/Route/Wec/Season_/Event_.elm
+++ b/app/app/Route/Wec/Season_/Event_.elm
@@ -25,6 +25,7 @@ import Motorsport.Utils exposing (compareBy)
 import Motorsport.Widget.BestLapTimes as BestLapTimesWidget
 import Motorsport.Widget.CloseBattles as CloseBattlesWidget
 import Motorsport.Widget.LapTimeProgression as LapTimeProgressionWidget
+import Motorsport.Widget.LiveStandings as LiveStandingsWidget
 import Motorsport.Widget.PositionProgression as PositionProgressionWidget
 import PagesMsg exposing (PagesMsg)
 import RouteBuilder exposing (App, StatefulRoute)
@@ -259,7 +260,15 @@ view app ({ eventSummary, analysis, raceControl } as shared) { mode, leaderboard
                                     , property "grid-template-rows" "1fr 400px"
                                     ]
                                 ]
-                                [ div [] []
+                                [ div
+                                    [ css
+                                        [ height (pct 100)
+                                        , overflowY scroll
+                                        , backgroundColor (hsl 0 0 0.15)
+                                        , padding (px 10)
+                                        ]
+                                    ]
+                                    [ LiveStandingsWidget.view eventSummary.season viewModel ]
                                 , div [ css [ property "display" "grid", property "place-items" "center" ] ]
                                     [ case ( eventSummary.season, eventSummary.name ) of
                                         ( 2025, "24 Hours of Le Mans" ) ->
@@ -276,7 +285,6 @@ view app ({ eventSummary, analysis, raceControl } as shared) { mode, leaderboard
                                         , padding (px 10)
                                         , property "display" "flex"
                                         , property "flex-direction" "column"
-                                        , property "gap" "24px"
                                         ]
                                     ]
                                     [ analysisWidgets raceControl analysis viewModel ]

--- a/app/app/Route/Wec/Season_/Event_.elm
+++ b/app/app/Route/Wec/Season_/Event_.elm
@@ -237,8 +237,7 @@ view app ({ eventSummary, analysis, raceControl } as shared) { mode, leaderboard
                     , property "grid-template-rows" "auto auto 1fr"
                     ]
                 ]
-                [ div [] [ text eventSummary.name ]
-                , navigation shared.raceControl
+                [ navigation shared.raceControl
                 , let
                     viewModel =
                         ViewModel.init raceControl
@@ -268,7 +267,7 @@ view app ({ eventSummary, analysis, raceControl } as shared) { mode, leaderboard
                                         , padding (px 10)
                                         ]
                                     ]
-                                    [ LiveStandingsWidget.view eventSummary.season viewModel ]
+                                    [ LiveStandingsWidget.view eventSummary viewModel ]
                                 , div [ css [ property "display" "grid", property "place-items" "center" ] ]
                                     [ case ( eventSummary.season, eventSummary.name ) of
                                         ( 2025, "24 Hours of Le Mans" ) ->

--- a/app/output.css
+++ b/app/output.css
@@ -8,6 +8,11 @@
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
     --spacing: 0.25rem;
+    --text-xs: 0.75rem;
+    --text-xs--line-height: calc(1 / 0.75);
+    --text-sm: 0.875rem;
+    --text-sm--line-height: calc(1.25 / 0.875);
+    --font-weight-bold: 700;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
@@ -211,21 +216,47 @@
   .table {
     display: table;
   }
-  .flex-1 {
-    flex: 1;
-  }
-  .flex-none {
-    flex: none;
-  }
   .transform {
     transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
+  }
+  .grid-cols-\[20px_30px_1fr_80px\] {
+    grid-template-columns: 20px 30px 1fr 80px;
+  }
+  .items-center {
+    align-items: center;
+  }
+  .gap-2 {
+    gap: calc(var(--spacing) * 2);
+  }
+  .rounded {
+    border-radius: 0.25rem;
   }
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
   }
+  .p-2 {
+    padding: calc(var(--spacing) * 2);
+  }
   .px-1 {
     padding-inline: calc(var(--spacing) * 1);
+  }
+  .py-1 {
+    padding-block: calc(var(--spacing) * 1);
+  }
+  .text-center {
+    text-align: center;
+  }
+  .text-right {
+    text-align: right;
+  }
+  .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+  }
+  .font-bold {
+    --tw-font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
   }
   .capitalize {
     text-transform: capitalize;
@@ -238,6 +269,9 @@
   }
   .italic {
     font-style: italic;
+  }
+  .opacity-60 {
+    opacity: 60%;
   }
   .shadow {
     --tw-shadow: 0 1px 3px 0 var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 1px 2px -1px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
@@ -284,6 +318,10 @@
   syntax: "*";
   inherits: false;
   initial-value: solid;
+}
+@property --tw-font-weight {
+  syntax: "*";
+  inherits: false;
 }
 @property --tw-shadow {
   syntax: "*";
@@ -453,6 +491,7 @@
       --tw-skew-x: initial;
       --tw-skew-y: initial;
       --tw-border-style: solid;
+      --tw-font-weight: initial;
       --tw-shadow: 0 0 #0000;
       --tw-shadow-color: initial;
       --tw-shadow-alpha: 100%;

--- a/app/output.css
+++ b/app/output.css
@@ -10,8 +10,6 @@
     --spacing: 0.25rem;
     --text-xs: 0.75rem;
     --text-xs--line-height: calc(1 / 0.75);
-    --text-sm: 0.875rem;
-    --text-sm--line-height: calc(1.25 / 0.875);
     --font-weight-bold: 700;
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -219,8 +217,8 @@
   .transform {
     transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
-  .grid-cols-\[20px_30px_1fr_80px\] {
-    grid-template-columns: 20px 30px 1fr 80px;
+  .grid-cols-\[20px_30px_1fr_auto\] {
+    grid-template-columns: 20px 30px 1fr auto;
   }
   .items-center {
     align-items: center;

--- a/package/src/Motorsport/Widget/LiveStandings.elm
+++ b/package/src/Motorsport/Widget/LiveStandings.elm
@@ -1,0 +1,57 @@
+module Motorsport.Widget.LiveStandings exposing (view)
+
+import Css exposing (backgroundColor, borderRadius, center, color, fontSize, fontWeight, hsl, padding, property, px, textAlign)
+import Html.Styled as Html exposing (Html, div, text)
+import Html.Styled.Attributes exposing (css)
+import Motorsport.Class as Class
+import Motorsport.Gap as Gap
+import Motorsport.RaceControl.ViewModel exposing (ViewModel, ViewModelItem)
+import Motorsport.Widget as Widget
+import SortedList
+
+
+view : Int -> ViewModel -> Html msg
+view season viewModel =
+    Widget.container ""
+        (div []
+            (viewModel.items
+                |> SortedList.toList
+                |> List.map (carRow season)
+            )
+        )
+
+
+carRow : Int -> ViewModelItem -> Html msg
+carRow season item =
+    div
+        [ css
+            [ property "padding-block" "8px"
+            , property "display" "grid"
+            , property "grid-template-columns" "20px 35px 1fr 80px"
+            , property "align-items" "center"
+            , property "column-gap" "8px"
+            , property "border-bottom" "1px solid hsl(0 0% 100% / 0.1)"
+            , property "font-size" "12px"
+            ]
+        ]
+        [ div [ css [ textAlign center ] ] [ text (String.fromInt item.position) ]
+        , div
+            [ css
+                [ textAlign center
+                , fontWeight Css.bold
+                , backgroundColor (Class.toHexColor season item.metadata.class)
+                , color (hsl 0 0 1)
+                , borderRadius (px 4)
+                , padding (px 4)
+                , fontSize (px 11)
+                ]
+            ]
+            [ text item.metadata.carNumber ]
+        , div []
+            [ div [ css [ fontWeight Css.bold ] ] [ text item.metadata.team ]
+            , div [ css [ fontSize (px 10), color (hsl 0 0 0.6) ] ]
+                [ text (item.currentDriver |> Maybe.map .name |> Maybe.withDefault "") ]
+            ]
+        , div [ css [ textAlign Css.right, fontSize (px 11) ] ]
+            [ text (Gap.toString item.timing.gap) ]
+        ]

--- a/package/src/Motorsport/Widget/LiveStandings.elm
+++ b/package/src/Motorsport/Widget/LiveStandings.elm
@@ -40,5 +40,5 @@ carRow season item =
                 [ text (item.currentDriver |> Maybe.map .name |> Maybe.withDefault "") ]
             ]
         , div [ class "text-xs text-right" ]
-            [ text (Gap.toString item.timing.gap) ]
+            [ text (Gap.toString item.timing.interval) ]
         ]

--- a/package/src/Motorsport/Widget/LiveStandings.elm
+++ b/package/src/Motorsport/Widget/LiveStandings.elm
@@ -1,6 +1,7 @@
 module Motorsport.Widget.LiveStandings exposing (view)
 
 import Css exposing (after, backgroundColor, property)
+import Data.Series.EventSummary exposing (EventSummary)
 import Html.Styled as Html exposing (Html, div, li, text, ul)
 import Html.Styled.Attributes exposing (class, css)
 import Motorsport.Class as Class
@@ -10,13 +11,13 @@ import Motorsport.Widget as Widget
 import SortedList
 
 
-view : Int -> ViewModel -> Html msg
-view season viewModel =
-    Widget.container ""
+view : EventSummary -> ViewModel -> Html msg
+view eventSummary viewModel =
+    Widget.container (eventSummary.name ++ " (" ++ String.fromInt eventSummary.season ++ ")")
         (ul [ class "list" ]
             (viewModel.items
                 |> SortedList.toList
-                |> List.map (carRow season)
+                |> List.map (carRow eventSummary.season)
             )
         )
 

--- a/package/src/Motorsport/Widget/LiveStandings.elm
+++ b/package/src/Motorsport/Widget/LiveStandings.elm
@@ -25,7 +25,7 @@ view eventSummary viewModel =
 carRow : Int -> ViewModelItem -> Html msg
 carRow season item =
     li
-        [ class "list-row p-2 grid-cols-[20px_30px_1fr_80px] items-center gap-2"
+        [ class "list-row p-2 grid-cols-[20px_30px_1fr_auto] items-center gap-2"
         , css [ after [ property "border-color" "hsl(0 0% 100% / 0.1)" ] ]
         ]
         [ div [ class "text-center text-xs" ] [ text (String.fromInt item.position) ]

--- a/package/src/Motorsport/Widget/LiveStandings.elm
+++ b/package/src/Motorsport/Widget/LiveStandings.elm
@@ -1,8 +1,8 @@
 module Motorsport.Widget.LiveStandings exposing (view)
 
-import Css exposing (backgroundColor, borderRadius, center, color, fontSize, fontWeight, hsl, padding, property, px, textAlign)
-import Html.Styled as Html exposing (Html, div, text)
-import Html.Styled.Attributes exposing (css)
+import Css exposing (after, backgroundColor, property)
+import Html.Styled as Html exposing (Html, div, li, text, ul)
+import Html.Styled.Attributes exposing (class, css)
 import Motorsport.Class as Class
 import Motorsport.Gap as Gap
 import Motorsport.RaceControl.ViewModel exposing (ViewModel, ViewModelItem)
@@ -13,7 +13,7 @@ import SortedList
 view : Int -> ViewModel -> Html msg
 view season viewModel =
     Widget.container ""
-        (div []
+        (ul [ class "list" ]
             (viewModel.items
                 |> SortedList.toList
                 |> List.map (carRow season)
@@ -23,35 +23,21 @@ view season viewModel =
 
 carRow : Int -> ViewModelItem -> Html msg
 carRow season item =
-    div
-        [ css
-            [ property "padding-block" "8px"
-            , property "display" "grid"
-            , property "grid-template-columns" "20px 35px 1fr 80px"
-            , property "align-items" "center"
-            , property "column-gap" "8px"
-            , property "border-bottom" "1px solid hsl(0 0% 100% / 0.1)"
-            , property "font-size" "12px"
-            ]
+    li
+        [ class "list-row p-2 grid-cols-[20px_30px_1fr_80px] items-center gap-2"
+        , css [ after [ property "border-color" "hsl(0 0% 100% / 0.1)" ] ]
         ]
-        [ div [ css [ textAlign center ] ] [ text (String.fromInt item.position) ]
+        [ div [ class "text-center text-xs" ] [ text (String.fromInt item.position) ]
         , div
-            [ css
-                [ textAlign center
-                , fontWeight Css.bold
-                , backgroundColor (Class.toHexColor season item.metadata.class)
-                , color (hsl 0 0 1)
-                , borderRadius (px 4)
-                , padding (px 4)
-                , fontSize (px 11)
-                ]
+            [ class "py-1 text-center text-xs font-bold rounded"
+            , css [ backgroundColor (Class.toHexColor season item.metadata.class) ]
             ]
             [ text item.metadata.carNumber ]
         , div []
-            [ div [ css [ fontWeight Css.bold ] ] [ text item.metadata.team ]
-            , div [ css [ fontSize (px 10), color (hsl 0 0 0.6) ] ]
+            [ div [ class "text-xs" ] [ text item.metadata.team ]
+            , div [ class "text-xs opacity-60" ]
                 [ text (item.currentDriver |> Maybe.map .name |> Maybe.withDefault "") ]
             ]
-        , div [ css [ textAlign Css.right, fontSize (px 11) ] ]
+        , div [ class "text-xs text-right" ]
             [ text (Gap.toString item.timing.gap) ]
         ]


### PR DESCRIPTION
This pull request introduces a new "Live Standings" widget to the WEC Event page and updates the styling system to support the new component. The main focus is on enhancing the user interface by displaying live race standings in a visually organized and modern way. Additionally, several new utility CSS classes and variables are added to support consistent styling across widgets.

**Feature: Live Standings Widget**
- Added a new `LiveStandings` widget (`Motorsport.Widget.LiveStandings`) that displays the current race standings, including position, car number, team, driver, and interval, styled in a responsive grid layout.
- Integrated the `LiveStandingsWidget` into the WEC Event page by importing it and rendering it within the main event view. The event name is now shown as the widget title, and the previous standalone event name header is removed for a cleaner layout. [[1]](diffhunk://#diff-ecf2c4ca668d416ea2bc535301c9300bfee8b27f8577c0281c07d6b20c6ed05fR28) [[2]](diffhunk://#diff-ecf2c4ca668d416ea2bc535301c9300bfee8b27f8577c0281c07d6b20c6ed05fL239-R240) [[3]](diffhunk://#diff-ecf2c4ca668d416ea2bc535301c9300bfee8b27f8577c0281c07d6b20c6ed05fL262-R270)

**Styling and CSS Utility Enhancements**
- Added new CSS variables for font sizes, font weights, and spacing, as well as new utility classes for grid layouts, alignment, padding, text formatting, and opacity. These support the new widget and improve overall design consistency. [[1]](diffhunk://#diff-d7b20e2c592bec8a6c516816876e48140dfd8c7c67bf11fd35983e29bd76e294R11-R13) [[2]](diffhunk://#diff-d7b20e2c592bec8a6c516816876e48140dfd8c7c67bf11fd35983e29bd76e294L214-R258) [[3]](diffhunk://#diff-d7b20e2c592bec8a6c516816876e48140dfd8c7c67bf11fd35983e29bd76e294R271-R273) [[4]](diffhunk://#diff-d7b20e2c592bec8a6c516816876e48140dfd8c7c67bf11fd35983e29bd76e294R320-R323) [[5]](diffhunk://#diff-d7b20e2c592bec8a6c516816876e48140dfd8c7c67bf11fd35983e29bd76e294R492)

**Layout Adjustments**
- Minor tweaks to the layout and spacing of the analysis widgets and event page to better accommodate the new live standings section and maintain visual balance.